### PR TITLE
docs(adr): adopt ISIN-based asset identity (ADR-012)

### DIFF
--- a/docs/adr/0006-asset-model-and-family-split.md
+++ b/docs/adr/0006-asset-model-and-family-split.md
@@ -1,6 +1,6 @@
 # ADR-006: Asset Model — Position vs Cash Families; `Asset` Hierarchy Scoped to Stock and Mutual Fund for v1
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-06-11)
 - **Date:** 2026-05-31
 - **Deciders:** Budi Yanto
 
@@ -44,6 +44,14 @@ Concrete decisions:
 - **The cash family gets no shared (sealed) supertype in v1.** RDN, Trading Balance, and `SavingsAccount` share only *"they hold a `Money` balance"* — which is **composition**, not a behavioural hierarchy. There is no consumer in v1 that receives "a cash account" and dispatches polymorphically over which kind it is. A thin shared interface is introduced *only later, if a concrete need appears* (e.g., a net-worth read-model that must enumerate and total all cash sources).
 
 - **RDN remains a `Money` field on `BrokerAccount`** — it is **not** promoted to a separate entity, despite having real-world bank/account-number attributes. The decision is made on **identity and lifecycle**, not attribute count: RDN is strictly one-to-one and lifecycle-bound to its `BrokerAccount` and is never referenced independently, so its identity *is* the `BrokerAccount`'s. RDN metadata (bank name, account number) is deferred until broker-statement reconciliation is built — which is already out of v1 scope per ADR-003.
+
+## Amendment — 2026-06-11: MF-identifier-as-ticker premise retracted (see ADR-012)
+
+The clause "MutualFund's identifier is modelled as a `Symbol` so the `Asset` contract holds uniformly" rested on an unverified premise: that mutual funds have a ticker-like symbol. Domain investigation showed they do not (funds are identified by name + investment manager; no uniform short code), while both stocks and funds carry an ISIN.
+
+The uniform `Asset` contract is **retained**, but on a corrected basis: every asset's identity is its **ISIN**, not a ticker. The full decision — `Symbol` → `AssetId` (ISIN-validated), the ticker/code demoted to a `shortCode` attribute on `Asset`, and the resulting `Asset` contract — is recorded in **ADR-012 (Asset Identity via ISIN)**, which supersedes this clause.
+
+This amendment changes only the *identifier* premise. ADR-006's substantive decisions — the position/cash family split, the `Asset` hierarchy scoped to Stock and MutualFund for v1, RDN-as-`Money`-field, Savings deferred — are unaffected.
 
 ## Alternatives Considered
 

--- a/docs/adr/0008-quantity-and-percentage-value-objects.md
+++ b/docs/adr/0008-quantity-and-percentage-value-objects.md
@@ -4,8 +4,6 @@
 - **Date:** 2026-05-31
 - **Deciders:** Budi Yanto
 
-> **Numbering note:** The domain model §11 had pencilled "ADR-008" in for the future *database strategy* decision. Because this Quantity/Percentage decision is the next ADR actually written, it takes number 008 (ADR numbers run in creation order). **Agreed:** the database-strategy ADR will be assigned a new (later) number, and the §11 reference updated accordingly.
-
 ## Context
 
 ADR-007 fixed the scale and rounding policy for **`Money`** (`HALF_EVEN`, scale 0, normalization in the compact constructor, factory methods as the public API) and explicitly scoped itself to currency — deferring `Quantity` and `Percentage`.
@@ -73,7 +71,7 @@ The **fee amount recorded on a transaction is the source of truth** (expected-vs
 - A generous `Percentage` scale removes a fragile precision dependency from fee math.
 
 ### Negative (costs we explicitly accept)
-- With one `Quantity` type, a share quantity and a unit quantity are the *same* Java type; nothing at the type level prevents mixing them in arithmetic. Mitigated because, within a single symbol's holding, all quantities are the same kind, so mixing never arises in correct code. A runtime same-kind guard can be added if a need appears. We accept slightly weaker type-safety in exchange for a simpler shared model.
+- With one `Quantity` type, a share quantity and a unit quantity are the *same* Java type; nothing at the type level prevents mixing them in arithmetic. Mitigated because, within a single asset's holding, all quantities are the same kind, so mixing never arises in correct code. A runtime same-kind guard can be added if a need appears. We accept slightly weaker type-safety in exchange for a simpler shared model.
 - Unit scale is fixed at 4. If a broker ever reports *reksa dana* units at finer than 4 dp, that input is **rejected by design** (not silently rounded) and the policy is revisited — a deliberate trade of flexibility for ledger-to-broker fidelity.
 
 ### Neutral / Open Questions

--- a/docs/adr/0012-asset-identity-via-isin.md
+++ b/docs/adr/0012-asset-identity-via-isin.md
@@ -1,0 +1,87 @@
+# ADR-012: Asset Identity via ISIN; Ticker/Code Demoted to a Display Label
+
+- **Status:** Accepted
+- **Date:** 2026-06-11
+- **Deciders:** Budi Yanto
+
+## Context
+
+We are about to implement the asset-identity value object and the Asset Catalog, so the identifier model must be settled now — it is the key for `Portfolio.holdings`, the reference on every `Acquisition` and `Transaction`, and the Asset Catalog's lookup key.
+
+The inherited model (domain model §4.3; ADR-006) used `Symbol` — a typed ticker validated as `[A-Z]{4}` for IDX — and ADR-006 declared MutualFund's identifier "modelled as a `Symbol` so the `Asset` contract holds uniformly." That uniformity was assumed, not verified.
+
+Investigation against real source data overturned the premise:
+
+- Indonesian **mutual funds have no ticker**. They are identified by name + investment manager; broker product codes (e.g., `KISI-FIPLUS`) are non-uniform and broker-specific, and KSEI "short codes" run 4–16 characters with no common format.
+- Fund **names are unstable** across sources — one fund (ISIN `IDN000053402`) appears as both "Reksa Dana ABF Indonesia Bond Index Fund" and "RD INDEKS ABF IBI FUND."
+- **Both stocks and funds carry a KSEI-issued ISIN** (ISO 6166: 2-char ISO-3166 country + 9-char NSIN + 1 Luhn check digit). In the investigation, the ISIN was the *only* identifier consistent across every source, and it is uniform across both v1 asset families.
+- A stock's 4-letter "Kode" (e.g., `AADI`) is a **label**, not an identity: it is exchange/vendor-decorated (`BBRI` vs Yahoo's `BBRI.JK`) and conceptually separate from the security.
+
+Constraints in force: correctness above all (this is money); ubiquitous language; and the v1 scope discipline of ADR-006 (defer with *known slots* rather than build speculatively).
+
+## Decision
+
+**An Asset's identity is its ISIN.**
+
+- Rename the identity value object `Symbol` → **`AssetId`**. In v1 it wraps and validates an ISIN: 12 chars, uppercase alphanumeric, ISO-6166 Luhn check digit. A malformed value throws `IllegalArgumentException` (a structural precondition, per ADR-011); `DomainException` is reserved for policy violations.
+- Because ISIN format is **uniform across Stock and MutualFund**, `AssetId` needs **no family-specific factories**.
+- `AssetId` equality is over the **ISIN alone** — a single-component `record`, so generated `equals`/`hashCode` are correct with no override.
+- The human handle (stock ticker / assigned fund code) is **demoted from the identity to a `shortCode` `String` attribute on `Asset`**, beside `name`. The catalog guarantees one `shortCode` per ISIN. `shortCode` is deliberately a plain validated `String`, not a value object.
+- The `Asset` contract becomes `AssetId id()`, `String name()`, `String shortCode()`.
+- The name is **concept-level (`AssetId`, not `Isin`)** so a future asset lacking an ISIN can be accommodated by broadening one type rather than renaming across `Acquisition`, `Holding`, and `Transaction`. v1 validation remains ISIN-strict; "an asset with no ISIN" is a **known slot**, not built now.
+- The ISIN remains directly available via `assetId.value()` for future broker-statement reconciliation and for display.
+
+## Alternatives Considered
+
+- **(A) Keep `Symbol` as the ticker/short code; store ISIN as an attribute** (the inherited model).
+    - Pros: matches the ubiquitous term for stocks; ergonomic to type.
+    - Cons: funds have no ticker, forcing an arbitrary user-assigned code *as identity*; the ticker is vendor-decorated and occasionally reassigned — a weak identity for a money app; reintroduces a family-specific factory split.
+    - Why rejected: identity must be stable and uniform; a ticker is neither, and funds can't supply one.
+
+- **(B) `Symbol{shortCode, ISIN}` with `equals` over the ISIN only.**
+    - Pros: keeps the human handle close to the identity in one object.
+    - Cons: a value object whose `equals` ignores a component breaks interchangeability — two "equal" instances can carry different `shortCode`s, so the `shortCode` inside a `Map` key is arbitrary and non-deterministic; forces a hand-written `equals` that fights the record; duplicates the label's home (drift risk).
+    - Why rejected: the equals-on-ISIN instinct was *correct* — and it proves `shortCode` is not part of the value, so it belongs on `Asset`. Making the ISIN the *whole* value is the clean expression of the same idea.
+
+- **(C) A minted surrogate internal id as identity; ticker/ISIN/KSEI code as attributes.**
+    - Pros: decoupled from every external scheme; never collides; uniform.
+    - Cons: discards the external anchoring of a perfectly good natural key (ISIN) to solve a multi-source reconciliation problem that does not exist in a single-user, hand-seeded v1; sacrifices ubiquitous-language-as-identity; pure ceremony at this scale.
+    - Why rejected: premature (YAGNI). Recorded as the option to revisit only if external identifiers ever prove unstable.
+
+- **(D) `AssetId` content correct, but name the type `Isin`.**
+    - Pros: maximally honest about what it holds today.
+    - Cons: names the implementation, not the concept; a future no-ISIN asset forces a rename ripple through `Acquisition`/`Holding`/`Transaction`.
+    - Why rejected: the concept-level name costs nothing now and saves that ripple later.
+
+- **(E) KSEI short code (e.g., `R-ABFII`) as identity.**
+    - Pros: KSEI-issued; shorter than an ISIN.
+    - Cons: non-uniform format (4–16 chars), national-scope only, and the long machine codes (`GR003MMSLKDSYA00`) aren't human-usable; not the cross-source-stable field ISIN is.
+    - Why rejected: fails the uniformity and stability tests ISIN passes.
+
+## Consequences
+
+### Positive
+- One uniform, globally-unique, stable identity across both v1 asset families — and the only field shown consistent across sources.
+- `AssetId` is a clean single-component value object: record `equals`/`hashCode` correct for free.
+- Identity and human label cleanly separated, in different homes.
+- Richer validation than `[A-Z]{4}` — a real ISO-6166 Luhn check digit, a high-value TDD target for a money app.
+- Eliminates a bug class: the catalog guarantees one `shortCode` per ISIN, so a mislabeled identity can't be constructed (unlike Alternative B, where `equals` couldn't see it).
+- Simplifies persistence (ADR-009): a single `VARCHAR(12)` column.
+- The `ofStock`/`ofFund` factory split implied by ADR-008's pattern **dissolves** for the identifier — the design got simpler as it got more correct.
+
+### Negative (costs we explicitly accept)
+- The internal key is not the term the investor types. The boundary must resolve `shortCode` → `AssetId`; mitigated because the Asset Catalog already performs boundary resolution (§6.2), so the cost is contained in one place.
+- A 12-char ISIN is less friendly to read/type than a ticker; mitigated by `shortCode`-based entry and display at the edge.
+- ISIN-strict v1 validation means a (currently hypothetical) no-ISIN asset cannot be recorded until `AssetId` is broadened — accepted as a known slot.
+
+### Neutral / Open Questions
+- Whether to enforce more ISIN structure than "12 uppercase-alphanumeric + Luhn" (e.g., first two chars are ISO-3166 letters). Resist hard-coding `ID` (over-fits v1). Decide when implementing.
+- `shortCode` validation kept loose (non-blank, trimmed, length cap); the strictness lives on `AssetId`.
+
+## References
+- ADR-006 — Asset model & family split (amended 2026-06-11; identity decision lifted here)
+- ADR-008 — Quantity/Percentage factory-method pattern (which *dissolves* for `AssetId`)
+- ADR-009 — Pure domain + separate JPA model (`AssetId` is a single-column record VO)
+- ADR-011 — Exception strategy (malformed ISIN → `IllegalArgumentException`)
+- Fintrackr Domain Model §2, §4.3, §6
+- ISO 6166 (ISIN); ISO 3166-1 (country codes)

--- a/docs/domain/domain-model.md
+++ b/docs/domain/domain-model.md
@@ -20,25 +20,26 @@ Fintrackr consolidates investment portfolios held across multiple Indonesian bro
 
 Terms in this section have *precise* meanings in code and conversation. Use them consistently.
 
-| Term | Definition |
-|---|---|
-| **Broker Account** | A regulated account with an Indonesian brokerage (e.g., Stockbit, Mandiri Sekuritas). Holds exactly one RDN. |
-| **RDN** | *Rekening Dana Nasabah* — the regulated cash balance at a broker, held in a partner bank under OJK rules. One per Broker Account. |
-| **Portfolio** | A logical grouping of investments inside a Broker Account (e.g., "Long-Term," "Trading"). Has its own *trading balance* — an allocated slice of the broker's RDN. |
-| **Trading Balance** | Cash available within a Portfolio for new investments. Sum of all Portfolio trading balances under a Broker Account equals the Broker Account's RDN. |
-| **Asset** | A tradable instrument: Stock, Mutual Fund, Bond, or Savings. Lives in the Asset Catalog context. Identified by Symbol. |
-| **Symbol** | A typed identifier for an Asset (e.g., `Symbol("BBCA")`). Format-validated; existence-validated only at system boundary. |
-| **Acquisition** | One immutable record of a single Buy decision: open date, open price, open fee, initial quantity. The unit of cost-basis tracking under Specific Identification. |
-| **Holding** | Derived/cached view of all open Acquisitions for a single Symbol within one Portfolio. Displays aggregate quantity, weighted average cost (for display only), invested value, market value, total dividends received. |
-| **Transaction** | An event that changes Portfolio state: Buy, Sell, Dividend, Deposit, or Withdrawal. Immutable once recorded; corrections happen by reversing transactions. |
-| **Sell Allocation** | Value object inside a Sell that specifies which Acquisition is being consumed and how many shares from it. A Sell has one or more. |
-| **Dividend Allocation** | Value object attached to a Acquisition recording the dividend received for that Acquisition at a given cum-date. |
-| **Cum-date** | Cumulative date — the last date an investor must hold the stock to be eligible for a declared dividend. |
-| **Acquisition Selection Strategy** | The rule that decides which Acquisition(s) a Sell consumes: FIFO, LIFO, Highest Cost, Lowest Cost, or Manual (user-specified). |
-| **Fee Structure** | The buy and sell fee rates configured at the Broker Account level. Used to compute expected fees, which the user can override. |
-| **Cost Basis** | The per-lot purchase price including fees, used to compute realized P&L on sells. |
-| **Realized P&L** | Profit or loss locked in by a Sell, computed per consumed Acquisition: `(sellPrice − acquisitionOpenPrice) × shares − allocatedFee`. |
-| **Per-Acquisition Total Return** | Capital gain plus dividends received during the acquisition's holding period — the user's preferred performance metric. |
+| Term                               | Definition                                                                                                                                                                                                            |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Broker Account**                 | A regulated account with an Indonesian brokerage (e.g., Stockbit, Mandiri Sekuritas). Holds exactly one RDN.                                                                                                          |
+| **RDN**                            | *Rekening Dana Nasabah* — the regulated cash balance at a broker, held in a partner bank under OJK rules. One per Broker Account.                                                                                     |
+| **Portfolio**                      | A logical grouping of investments inside a Broker Account (e.g., "Long-Term," "Trading"). Has its own *trading balance* — an allocated slice of the broker's RDN.                                                     |
+| **Trading Balance**                | Cash available within a Portfolio for new investments. Sum of all Portfolio trading balances under a Broker Account equals the Broker Account's RDN.                                                                  |
+| **Asset**                          | A tradable instrument: Stock, Mutual Fund, Bond, or Savings. Lives in the Asset Catalog context. Identified by AssetId (its ISIN).                                                                                    |
+| **Asset Id**                       | The stable identity of an Asset: its ISIN (ISO 6166 — 12 chars, Luhn check digit). Equality is over the ISIN alone. Format-validated in its constructor; existence-validated only at system boundary.                 |
+| **Short Code**                     | An Asset's human handle, a stock's IDX ticker (e.g., AADI) or an assigned fund code. A display/lookup label on the Asset, never the identity; not guaranteed stable across vendors.                                   |
+| **Acquisition**                    | One immutable record of a single Buy decision: open date, open price, open fee, initial quantity. The unit of cost-basis tracking under Specific Identification.                                                      |
+| **Holding**                        | Derived/cached view of all open Acquisitions for a single Symbol within one Portfolio. Displays aggregate quantity, weighted average cost (for display only), invested value, market value, total dividends received. |
+| **Transaction**                    | An event that changes Portfolio state: Buy, Sell, Dividend, Deposit, or Withdrawal. Immutable once recorded; corrections happen by reversing transactions.                                                            |
+| **Sell Allocation**                | Value object inside a Sell that specifies which Acquisition is being consumed and how many shares from it. A Sell has one or more.                                                                                    |
+| **Dividend Allocation**            | Value object attached to a Acquisition recording the dividend received for that Acquisition at a given cum-date.                                                                                                      |
+| **Cum-date**                       | Cumulative date — the last date an investor must hold the stock to be eligible for a declared dividend.                                                                                                               |
+| **Acquisition Selection Strategy** | The rule that decides which Acquisition(s) a Sell consumes: FIFO, LIFO, Highest Cost, Lowest Cost, or Manual (user-specified).                                                                                        |
+| **Fee Structure**                  | The buy and sell fee rates configured at the Broker Account level. Used to compute expected fees, which the user can override.                                                                                        |
+| **Cost Basis**                     | The per-lot purchase price including fees, used to compute realized P&L on sells.                                                                                                                                     |
+| **Realized P&L**                   | Profit or loss locked in by a Sell, computed per consumed Acquisition: `(sellPrice − acquisitionOpenPrice) × shares − allocatedFee`.                                                                                  |
+| **Per-Acquisition Total Return**   | Capital gain plus dividends received during the acquisition's holding period — the user's preferred performance metric.                                                                                               |
 
 ---
 
@@ -49,14 +50,14 @@ Three contexts, each with a clear responsibility.
 ```
                  ┌───────────────────────┐
                  │   Asset Catalog       │   reference data
-                 │   (Symbols, Stocks,   │   lifecycle: external
-                 │    Mutual Funds, etc.)│   referenced by Symbol
+                 │   (Asset Ids, Stocks, │   lifecycle: external
+                 │    Mutual Funds, etc.)│   referenced by AssetId
                  └───────────▲───────────┘
-                             │ Symbol lookup
+                             │ AssetId lookup
                              │ (boundary validation only)
                              │
 ┌────────────────────────┐   │    ┌─────────────────────────────────┐
-│   Brokerage            │◀──┴───│   Portfolio Management          │
+│   Brokerage            │◀──┴─── │   Portfolio Management          │
 │                        │        │                                 │
 │   Broker Account       │        │   Portfolio (aggregate)         │
 │   RDN                  │◀───────│  Acquisitions, Sells, Dividends │
@@ -91,7 +92,7 @@ Portfolio (aggregate root, entity)
 ├─ defaultAcquisitionSelectionStrategy: AcquisitionSelectionStrategy
 ├─ acquisitions: List<Acquisition>           ← immutable on creation
 ├─ transactions: List<Transaction>  ← append-only ledger (Buy, Sell, Dividend, Deposit, Withdrawal)
-└─ holdings: Map<Symbol, Holding>   ← cached, derived from open Acquisitions (per ADR-004)
+└─ holdings: Map<AssetId, Holding>   ← cached, derived from open Acquisitions (per ADR-004)
 ```
 
 ### 4.2 Entities
@@ -102,7 +103,7 @@ Portfolio (aggregate root, entity)
 Acquisition
 ├─ id
 ├─ portfolioId
-├─ symbol: Symbol
+├─ assetId: AssetId
 ├─ openDate
 ├─ openPrice: Money
 ├─ openFee: Money
@@ -121,13 +122,13 @@ sealed interface Transaction
     permits Buy, Sell, Dividend, Deposit, Withdrawal { }
 ```
 
-| Subtype | Attributes |
-|---|---|
-| `Buy` | id, portfolioId, symbol, date, quantity, price, fee, acquisitionId (the Acquisition it opened) |
-| `Sell` | id, portfolioId, symbol, date, pricePerShare, totalFee, allocations: List\<SellAllocation\> |
-| `Dividend` | id, portfolioId, symbol, cumDate, paymentDate, dps (dividend per share), allocations: List\<DividendAllocation\> |
-| `Deposit` | id, portfolioId, amount, date, source (e.g., "RDN") |
-| `Withdrawal` | id, portfolioId, amount, date, destination |
+| Subtype | Attributes                                                                                                        |
+|---|-------------------------------------------------------------------------------------------------------------------|
+| `Buy` | id, portfolioId, assetId, date, quantity, price, fee, acquisitionId (the Acquisition it opened)                   |
+| `Sell` | id, portfolioId, assetId, date, pricePerShare, totalFee, allocations: List\<SellAllocation\>                      |
+| `Dividend` | id, portfolioId, assetId, cumDate, paymentDate, dps (dividend per share), allocations: List\<DividendAllocation\> |
+| `Deposit` | id, portfolioId, amount, date, source (e.g., "RDN")                                                               |
+| `Withdrawal` | id, portfolioId, amount, date, destination                                                                        |
 
 All Transactions are immutable once recorded. Corrections are made by recording a reversing transaction, never by editing.
 
@@ -136,7 +137,7 @@ All Transactions are immutable once recorded. Corrections are made by recording 
 ```
 Holding (derived)
 ├─ portfolioId
-├─ symbol
+├─ assetId
 ├─ totalQuantity         = Σ openAcquisitions.remainingQuantity
 ├─ averageCost (display) = weighted average of open acquisitions' openPrice (for display only — not the basis of accounting)
 ├─ totalInvested         = Σ openAcquisitions.remainingQuantity × openAcquisitions.openPrice + openFee proportion
@@ -148,15 +149,15 @@ Holding (derived)
 
 ### 4.3 Value Objects
 
-| Value Object | Shape | Validation |
-|---|---|---|
-| `Symbol(String value)` | Typed wrapper around ticker | Non-blank; uppercase; matches `[A-Z]{4}` for IDX (refine for mutual funds, bonds later) |
-| `Money(BigDecimal amount, Currency currency)` | All monetary values | amount ≥ 0 for balances; signed for deltas; rounding mode TBD (see ADR-007) |
-| `Quantity(BigDecimal value)` | Shares / units | value > 0 for transactions; ≥ 0 for derived state |
-| `Percentage(BigDecimal rate)` | Used for fee rates | 0 ≤ rate ≤ 1 |
-| `SellAllocation(acquisitionId, sharesSoldFromAcquisition, feeAllocated)` | Inside `Sell` | sharesSoldFromAcquisition > 0; sharesSoldFromAcquisition ≤ acquisition.remainingQuantity at sell time; feeAllocated proportional |
-| `DividendAllocation(cumDate, paymentDate, dps, sharesEligibleAtCumDate, amount)` | Attached to `Acquisition` | sharesEligibleAtCumDate > 0; amount = sharesEligibleAtCumDate × dps |
-| `AcquisitionSelectionStrategy` | Sealed interface | See below |
+| Value Object                                                                     | Shape                                 | Validation |
+|----------------------------------------------------------------------------------|---------------------------------------|---|
+| `AssetId(String value)`                                                          | Typed asset identity wrapping an ISIN | 12 chars; uppercase alphanumeric; ISO-6166 Luhn check digit; malformed → `llegalArgumentException` (ADR-011); equality over the ISIN |
+| `Money(BigDecimal amount, Currency currency)`                                    | All monetary values                   | amount ≥ 0 for balances; signed for deltas; rounding mode TBD (see ADR-007) |
+| `Quantity(BigDecimal value)`                                                     | Shares / units                        | value > 0 for transactions; ≥ 0 for derived state |
+| `Percentage(BigDecimal rate)`                                                    | Used for fee rates                    | 0 ≤ rate ≤ 1 |
+| `SellAllocation(acquisitionId, sharesSoldFromAcquisition, feeAllocated)`         | Inside `Sell`                         | sharesSoldFromAcquisition > 0; sharesSoldFromAcquisition ≤ acquisition.remainingQuantity at sell time; feeAllocated proportional |
+| `DividendAllocation(cumDate, paymentDate, dps, sharesEligibleAtCumDate, amount)` | Attached to `Acquisition`             | sharesEligibleAtCumDate > 0; amount = sharesEligibleAtCumDate × dps |
+| `AcquisitionSelectionStrategy`                                                   | Sealed interface                      | See below |
 
 #### `AcquisitionSelectionStrategy` (sealed)
 
@@ -177,22 +178,22 @@ Each Portfolio has a `defaultAcquisitionSelectionStrategy`. Every `recordSell` c
 
 All in business language. Each enforces its invariants internally before changing state.
 
-| Method | Purpose |
-|---|---|
-| `recordBuy(symbol, quantity, price, fee, date)` | Opens a new Acquisition; updates Holding cache; decrements tradingBalance; **returns the cash delta moved (`quantity × price + fee` as `Money`)** so the orchestrating app service applies that exact value to RDN (single source of truth — no recomputation, no drift); emits `BuyRecorded` event |
-| `recordSell(symbol, quantity, pricePerShare, fee, date, strategy)` | Resolves allocations via strategy; validates against open Acquisitions; updates referenced Acquisitions (derived state changes); updates Holding cache; increments tradingBalance; emits `SellRecorded` event |
-| `recordDividend(symbol, dps, cumDate, paymentDate)` | For every eligible Acquisition of `symbol`, appends a DividendAllocation; increments tradingBalance; emits `DividendReceived` event |
-| `recordDeposit(amount, date, source)` | Increments tradingBalance from external cash inflow; emits `DepositRecorded` |
-| `recordWithdrawal(amount, date, destination)` | Decrements tradingBalance; emits `WithdrawalRecorded` |
-| `transferTo(targetPortfolioId, amount, date)` | Moves cash between portfolios under the same broker (preserves RDN total) |
+| Method                                                             | Purpose |
+|--------------------------------------------------------------------|---|
+| `recordBuy(assetId, quantity, price, fee, date)`                   | Opens a new Acquisition; updates Holding cache; decrements tradingBalance; **returns the cash delta moved (`quantity × price + fee` as `Money`)** so the orchestrating app service applies that exact value to RDN (single source of truth — no recomputation, no drift); emits `BuyRecorded` event |
+| `recordSell(assetId, quantity, pricePerShare, fee, date, strategy)` | Resolves allocations via strategy; validates against open Acquisitions; updates referenced Acquisitions (derived state changes); updates Holding cache; increments tradingBalance; emits `SellRecorded` event |
+| `recordDividend(assetId, dps, cumDate, paymentDate)`                | For every eligible Acquisition of `symbol`, appends a DividendAllocation; increments tradingBalance; emits `DividendReceived` event |
+| `recordDeposit(amount, date, source)`                              | Increments tradingBalance from external cash inflow; emits `DepositRecorded` |
+| `recordWithdrawal(amount, date, destination)`                      | Decrements tradingBalance; emits `WithdrawalRecorded` |
+| `transferTo(targetPortfolioId, amount, date)`                      | Moves cash between portfolios under the same broker (preserves RDN total) |
 
 ### 4.5 Domain events emitted
 
 Typed events (Spring Modulith `@ApplicationModuleListener` consumers):
 
-- `BuyRecorded(portfolioId, acquisitionId, symbol, quantity, price, fee, date)`
-- `SellRecorded(portfolioId, sellId, symbol, allocations, pricePerShare, fee, date)`
-- `DividendReceived(portfolioId, symbol, allocations, paymentDate)`
+- `BuyRecorded(portfolioId, acquisitionId, assetId, quantity, price, fee, date)`
+- `SellRecorded(portfolioId, sellId, assetId, allocations, pricePerShare, fee, date)`
+- `DividendReceived(portfolioId, assetId, allocations, paymentDate)`
 - `DepositRecorded(portfolioId, amount, date, source)`
 - `WithdrawalRecorded(portfolioId, amount, date, destination)`
 - `TradingBalanceChanged(portfolioId, delta, newBalance)` ← consumed by Brokerage to sync RDN. The cash sync to BrokerAccount RDN is performed by application-service orchestration in one transaction per ADR-003, not by a domain event in v1. A `TradingBalanceChanged` integration event is deferred until a read-model consumer needs it or the modules are split into services.
@@ -244,19 +245,20 @@ Reference data. Lightweight in v1.
 
 ```java
 sealed interface Asset permits Stock, MutualFund {
-    Symbol symbol();
+    AssetId id();
     String name();
+    String shortCode();
 }
 ```
 
-- **Stock** — symbol, name, sector, currentPrice (eventually fed by external market data)
-- **MutualFund** — code, name, currentNAV
+- **Stock** — id, name, shortCode (IDX ticker), sector, currentPrice (eventually fed by external market data), priceAsOf
+- **MutualFund** — id, name, shortCode (assigned fund code), currentNAV, navAsOf
 
 V1 implementation: small in-memory list seeded manually (Stockbit's most common Indonesian tickers). Future: external feed integration.
 
 ### 6.2 Boundary validation
 
-When Portfolio Management receives a Symbol from the outside (UI, API, importer), it queries Asset Catalog: *"is this Symbol known?"* If not, the operation is rejected at the boundary. Inside the Portfolio aggregate, Symbol existence is trusted.
+Portfolio Management receives an asset reference from outside (UI, API, importer), typically a `shortCode` the user typed, or an `AssetId`; it queries Asset Catalog: *"is this Symbol known?"* If not, the operation is rejected at the boundary; Inside the Portfolio aggregate, `AssetId` existence is trusted.
 
 ---
 
@@ -273,7 +275,7 @@ Migration to event-driven eventual consistency (transactional outbox + listener)
 
 ### 7.2 Asset existence validation
 
-Boundary check only: Portfolio Management consults Asset Catalog when accepting a new Symbol from outside. Internal references trust the data.
+Boundary check only: Portfolio Management consults Asset Catalog when accepting a new asset reference (`shortCode`/`AssetId`) from outside. Internal references trust the data.
 
 ---
 
@@ -290,7 +292,7 @@ Boundary check only: Portfolio Management consults Asset Catalog when accepting 
 - All quantities `> 0`, prices `> 0`, fees `≥ 0`
 - Dividend allocations only on Acquisitions where `openDate ≤ cumDate AND sharesEligibleAtCumDate > 0`
 - Acquisitions are immutable after creation (only derived `remainingQuantity` and `status` change)
-- At most one active Holding per Symbol per Portfolio
+- At most one active Holding per AssetId per Portfolio
 
 ### `BrokerAccount`
 - `rdn ≥ 0`
@@ -298,14 +300,15 @@ Boundary check only: Portfolio Management consults Asset Catalog when accepting 
 - Cross-aggregate (see §7.1): `sum(portfolios.tradingBalance) == rdn`
 
 ### `Asset` (catalog)
-- `Symbol` is unique within the catalog
+- `AssetId` is unique within the catalog
+- `shortCode` is unique within the catalog so user input resolves unambiguously
 
 ---
 
 ## 9. Tactical guidance — patterns to follow
 
 - **Tell, Don't Ask.** Methods on aggregates use business language (`recordBuy`, not `setHoldings`). No public setters on internal entities. Callers express intent; aggregates enforce rules.
-- **Primitive obsession is forbidden.** No raw `String` symbols, no raw `BigDecimal` money, no raw `int` quantities. Every primitive concept gets a typed value object with validation in its constructor.
+- **Primitive obsession is forbidden.** No raw `String` identifiers, no raw `BigDecimal` money, no raw `int` quantities. Every primitive concept gets a typed value object with validation in its constructor.
 - **Immutability bias.** Acquisitions, transactions, value objects are immutable once created. Mutations happen by appending new events (Sells, DividendAllocations) that reference the original.
 - **Boundary validation.** Validate at the edges. Trust data inside the domain.
 - **Domain events are typed and module-internal** (Spring Modulith `@ApplicationModuleListener`). No string-named topics in v1.
@@ -345,6 +348,8 @@ These are deliberate parking lots. Track in `backlog.md`; revisit when implement
 - ADR-003 — Cross-aggregate cash invariant
 - ADR-004 — Transaction ledger as source of truth; Holding cached
 - ADR-005 — Specific Identification cost basis with per-lot dividend attribution
+- ADR-006 — Asset model and family split
+- ADR-012 — Asset identity via ISIN
 - Fintrackr Vision (`01-fintrackr-vision.md`)
 - Eric Evans, *Domain-Driven Design*
 - Vaughn Vernon, *Implementing Domain-Driven Design* — aggregate design chapters


### PR DESCRIPTION
## What
Records the decision to identify assets by their ISIN and propagates it through the architecture docs. Documentation only — no code.

## Why
The inherited model identified assets by a ticker-style `Symbol` (`[A-Z]{4}`). Checking real sources (KSEI registry, a Mandiri Sekuritas MF statement, fund fact sheets) showed: Indonesian mutual funds have no ticker; fund names are unstable across sources (one fund, ISIN IDN000053402, appears under two names); and the ISIN is the only identifier that is unique, stable, and uniform across both stocks and funds. A four-letter ticker (e.g. AADI) is a vendor-decorated *label* — BBRI vs Yahoo's BBRI.JK — not an identity.

## Decision (ADR-012)
- `Symbol` → `AssetId`: a single-component value object wrapping an ISIN (12 chars, uppercase alphanumeric, ISO-6166 Luhn check digit). Equality over the ISIN alone; malformed input → `IllegalArgumentException` (ADR-011).
- The ticker / assigned fund code is demoted to a `shortCode` attribute on `Asset`, beside `name` — never the identity.
- Name is concept-level (`AssetId`, not `Isin`) so a future no-ISIN asset is a one-type broadening, not a repo-wide rename. v1 stays ISIN-strict (known slot).

## Files
- `docs/adr/0012-asset-identity-via-isin.md` — new; decision of record.
- `docs/adr/0006-...` — amended: retracts the "MF identifier = ticker" premise and points to ADR-012; ADR-006's substantive decisions are unchanged.
- `docs/domain-model.md` — propagates `Symbol`→`AssetId`, adds `shortCode`, updates the `Asset` contract, boundary validation (§6.2/§7.2), and invariants.