### PR TITLE
feat(shared): implement AssetId value object with ISIN validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
             <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.10.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/budiyanto/fintrackr/shared/AssetId.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/AssetId.java
@@ -1,0 +1,24 @@
+package com.budiyanto.fintrackr.shared;
+
+import org.apache.commons.validator.routines.checkdigit.ISINCheckDigit;
+
+import java.util.Objects;
+
+public record AssetId(String value) {
+
+    public AssetId {
+        Objects.requireNonNull(value);
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("Isin value cannot be blank");
+        }
+
+        if (!ISINCheckDigit.ISIN_CHECK_DIGIT.isValid(value)) {
+             throw new IllegalArgumentException("Isin value should be Luhn check digit");
+        }
+    }
+
+    public static AssetId of(String value) {
+        return new AssetId(value);
+    }
+
+}

--- a/src/test/java/com/budiyanto/fintrackr/shared/AssetIdTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/shared/AssetIdTest.java
@@ -1,0 +1,72 @@
+package com.budiyanto.fintrackr.shared;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("AssetId Tests")
+class AssetIdTest {
+
+    // 1. Happy path
+    @Test
+    @DisplayName("Given a valid ISIN string, when constructed, then return a valid AssetId")
+    void should_returnValidAssetId_when_constructed() {
+        // Given
+        String isin = "IDN000053402";  // ISIN of ABF Fund
+
+        // When
+        AssetId result = AssetId.of(isin);
+
+        // Then
+        assertThat(result.value()).isEqualTo(isin);
+    }
+
+    // 2. Null -> rejected
+    @ParameterizedTest
+    @NullSource
+    @DisplayName("Given a null String, when constructed, then throws an NullPointerException")
+    void should_throwException_when_nullStringIsGiven(String invalidIsin) {
+        // Then
+        assertThatThrownBy(() -> AssetId.of(invalidIsin))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // 3. Empty / Blank -> rejected
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {" ", "  ", "\t", "\n"})
+    @DisplayName("Given empty or blank String, when constructed, then throws an IllegalArgumentException")
+    void should_throwException_when_emptyOrBlankStringIsGiven(String invalidIsin) {
+        // Then
+        assertThatThrownBy(() -> AssetId.of(invalidIsin))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // 4. wrong length (not 12) -> rejected
+    @ParameterizedTest
+    @ValueSource(strings = {"abcdefghijk", "abcdefghijklm"})
+    @DisplayName("Given a String with a length other than 12, when constructed, then throws an IllegalArgumentException")
+    void should_throwException_when_isinStringLengthNot12(String invalidIsin) {
+        assertThatThrownBy(() -> AssetId.of(invalidIsin))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // 5. fails Luhn -> rejected
+    @Test
+    @DisplayName("Given an ISIN string that fails the Luhn checksum validation, when constructed, then throws an IllegalArgumentException")
+    void should_throwException_when_badLuhn() {
+        // Given
+        String invalidIsin = "IDN000053409";
+
+        // When & Then
+        assertThatThrownBy(() -> AssetId.of(invalidIsin))
+                .isInstanceOf(IllegalArgumentException.class);
+
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `AssetId` value object in the `shared` module, wrapping an ISIN (ISO 6166) as the stable identity for all assets (ADR-012)
- Validation: null → NPE, blank → IAE, invalid ISIN (bad format or failed check digit) → IAE, delegating to Apache Commons `ISINCheckDigit`
- Replaces the placeholder `Symbol` concept from earlier sessions

## What changed
- `AssetId.java` — record with compact constructor enforcing ISIN validation
- `AssetIdTest.java` — TDD test suite: happy path, null, blank, wrong length, bad Luhn

## Test plan
- [x] All `AssetIdTest` cases green
- [x] Null throws `NullPointerException` (ADR-011)
- [x] Blank/malformed throws `IllegalArgumentException` (ADR-011)
- [x] Valid ISIN (`IDN000053402`) constructs and round-trips correctly