### PR TITLE
feat(portfolio): implement Quantity value object with ofShares and ofUnits factory methods

### DIFF
--- a/docs/adr/0008-quantity-and-percentage-value-objects.md
+++ b/docs/adr/0008-quantity-and-percentage-value-objects.md
@@ -24,7 +24,7 @@ Two facts from ADR-006 constrain the choice:
   - `Quantity.ofUnits(BigDecimal)` — fractional; **canonical scale 4** (matches Indonesian *reksa dana* unit reporting); **rejects** input finer than scale 4 rather than rounding it.
 - **`Quantity` never rounds.** It stores the value faithfully and rejects malformed input. Rationale: a quantity — especially an MF unit count — is a *recorded fact* from the broker (ADR-004); silently rounding it would desync our ledger from the broker. This is the deliberate **opposite** of `Money`, which *rounds* because IDR has no functional subunit. (Two value objects, two rounding stances, each justified by domain meaning.)
 - **Scale is canonicalized at construction** (pad to the canonical scale; reject if finer). Because every share quantity is then scale 0 and every unit quantity is the same fixed scale, two numerically-equal quantities always carry the same scale — which makes the record's generated `equals`/`hashCode` correct *despite* `BigDecimal.equals` considering scale (`5.0` ≠ `5.00`). No custom `equals` needed.
-- **Intrinsic guards** (`value > 0` for transaction quantities; `≥ 0` for derived state) live in the value object, per the Session-2 guard-placement decision.
+- **Intrinsic guards**: `≥ 0` for derived state enforced in the VO (structural guard), `value > 0` for transaction quantities enforced in the aggregate when recording a transaction (business rule).
 
 ### `Percentage`
 

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Quantity.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Quantity.java
@@ -1,0 +1,58 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+public class Quantity {
+
+    private final BigDecimal value;
+
+    private Quantity(BigDecimal value) {
+        Objects.requireNonNull(value, "Quantity value must not be null");
+        if (value.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Quantity value cannot be negative");
+        }
+        this.value = value;
+    }
+
+    public static Quantity ofShares(BigDecimal value) {
+        BigDecimal normalizedValue = normalize(value);
+        if (normalizedValue.scale() != 0) {
+            throw new IllegalArgumentException("Quantity of shares must be a whole number");
+        }
+        return new Quantity(normalizedValue);
+    }
+
+    public static Quantity ofUnits(BigDecimal value) {
+        BigDecimal normalizedValue = normalize(value);
+        if (normalizedValue.scale() > 4) {
+            throw new IllegalArgumentException("Quantity of units cannot have more than 4 decimal places");
+        }
+        return new Quantity(value.setScale(4, RoundingMode.UNNECESSARY));
+    }
+
+    public BigDecimal value() { return value; }
+
+    // Strip tailing zeros to normalize (e.g., 10.00 -> 10)
+    private static BigDecimal normalize(BigDecimal value) {
+        Objects.requireNonNull(value, "Quantity value must not be null");
+        BigDecimal normalizedValue = value.stripTrailingZeros();
+        if (normalizedValue.scale() <= 0) {
+            normalizedValue = normalizedValue.setScale(0, RoundingMode.UNNECESSARY);
+        }
+        return normalizedValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Quantity quantity = (Quantity) o;
+        return Objects.equals(value, quantity.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+}

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/QuantityTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/QuantityTest.java
@@ -1,0 +1,170 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Quantity Tests")
+class QuantityTest {
+
+    @Nested
+    @DisplayName("ofShares Tests")
+    class OfSharesConstructor {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"10", "25", "1000", "100.00", "28.00"})
+        @DisplayName("Given a whole number, when ofShares is called, then a Quantity is created successfully")
+        void should_returnQuantity_when_valueIsWholeNumber(String input) {
+            // Given
+            BigDecimal value = new BigDecimal(input);
+
+            // When
+            Quantity result = Quantity.ofShares(value);
+
+            // Then
+            assertThat(result.value()).isEqualByComparingTo(value);
+            assertThat(result.value().scale()).isEqualTo(0);
+
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @DisplayName("Given a null value, when constructed, then throws a NullPointerException")
+        void should_throwException_when_valueIsNull(BigDecimal nullValue) {
+            // When & Then
+            assertThatThrownBy(() -> Quantity.ofShares(nullValue))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1000", "-1245.00", "-1234.8789"})
+        @DisplayName("Given a negative value, when constructed, then throws an IllegalArgumentException")
+        void should_throwException_when_valueIsNegative(String input) {
+            // Given
+            BigDecimal negativeValue = new BigDecimal(input);
+
+            // When & Then
+            assertThatThrownBy(() -> Quantity.ofShares(negativeValue))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"10.5", "10.678", "15.120"})
+        @DisplayName("Given a non-whole number, when ofShares is called, then throws an IllegalArgumentException")
+        void should_throwException_when_valueIsNotWholeNumber(String input) {
+            // Given
+            BigDecimal value = new BigDecimal(input);
+
+            // When & Then
+            assertThatThrownBy(() -> Quantity.ofShares(value))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "10, 10",
+                "15, 15.00",
+        })
+        @DisplayName("Given 2 same values, when comparing, then return true")
+        void should_returnTrue_when_comparingTwoEqualQuantities(String input1, String input2) {
+            // Given
+            BigDecimal value1 = new BigDecimal(input1);
+            BigDecimal value2 = new BigDecimal(input2);
+
+            // When
+            Quantity quantity1 = Quantity.ofShares(value1);
+            Quantity quantity2 = Quantity.ofShares(value2);
+
+            // Then
+            assertThat(quantity1).isEqualTo(quantity2);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("ofUnits Tests")
+    class OfUnitsConstructor {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"10", "10.5", "10.38", "10.258", "10.3894", "15.3230", "18.129300"})
+        @DisplayName("Given a value with a scale of 4 or less, when ofUnits is called, then a Quantity is created successfully")
+        void should_returnQuantity_when_valueHasScaleLessEqual4(String input) {
+            // Given
+            BigDecimal value = new BigDecimal(input);
+
+            // When
+            Quantity result = Quantity.ofUnits(value);
+
+            // Then
+            assertThat(result.value()).isEqualByComparingTo(value);
+            assertThat(result.value().scale()).isEqualTo(4);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @DisplayName("Given a null value, when constructed, then throws a NullPointerException")
+        void should_throwException_when_valueIsNull(BigDecimal nullValue) {
+            // When & Then
+            assertThatThrownBy(() -> Quantity.ofUnits(nullValue))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1000", "-1245.00", "-1234.8789"})
+        @DisplayName("Given a negative value, when constructed, then throws an IllegalArgumentException")
+        void should_throwException_when_valueIsNegative(String input) {
+            // Given
+            BigDecimal negativeValue = new BigDecimal(input);
+
+            // When & Then
+            assertThatThrownBy(() -> Quantity.ofUnits(negativeValue))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"10.12345", "10.232023"})
+        @DisplayName("Given a value with a scale greater than 4, when ofUnits is called, then throws an IllegalArgumentException")
+        void should_throwException_when_valueHasScaleGreaterThan4(String input) {
+            // Given
+            BigDecimal value = new BigDecimal(input);
+
+            // When & Then
+            assertThatThrownBy(() -> Quantity.ofUnits(value))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "10, 10",
+                "15, 15.00",
+                "15.12, 15.1200",
+                "15.345, 15.345",
+                "13.2122, 13.2122"
+        })
+        @DisplayName("Given 2 same values, when comparing, then return true")
+        void should_returnTrue_when_comparingTwoEqualQuantities(String input1, String input2) {
+            // Given
+            BigDecimal value1 = new BigDecimal(input1);
+            BigDecimal value2 = new BigDecimal(input2);
+
+            // When
+            Quantity quantity1 = Quantity.ofUnits(value1);
+            Quantity quantity2 = Quantity.ofUnits(value2);
+
+            // Then
+            assertThat(quantity1).isEqualTo(quantity2);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Summary
- Implements `Quantity` value object in the `portfolio` module as a `class` (not `record`) to enforce private constructor and guarantee scale invariants through factory methods
- `ofShares(BigDecimal)` — accepts whole numbers only (scale 0); rejects fractions
- `ofUnits(BigDecimal)` — accepts scale ≤ 4; canonicalizes to scale 4 (matches Indonesian reksa dana broker reporting per ADR-008)
- `Quantity` never rounds — it rejects malformed input (opposite stance to `Money`)
- Companion update: ADR-008 corrected — `value > 0` for transactions enforced in the aggregate, not the VO

## What changed
- `Quantity.java` — switched from `record` to `class`; private constructor; `ofShares`/`ofUnits` factory methods; hand-rolled `equals`/`hashCode` (safe because scale is canonicalized at construction)
- `QuantityTest.java` — full TDD suite including equality tests proving cross-scale correctness
- `docs/adr/0008-quantity-and-percentage-value-objects.md` — corrected guard placement

## Test plan
- [x] All `QuantityTest` cases green
- [x] `ofShares` rejects fractions and negative values
- [x] `ofUnits` rejects scale > 4 and negative values; pads coarser scales to 4
- [x] Equality holds across different input representations of the same value