### PR TITLE
docs: sync ADRs and domain model to ISIN-based AssetId identity

### DIFF
--- a/docs/adr/0002-testing-strategy.md
+++ b/docs/adr/0002-testing-strategy.md
@@ -23,7 +23,7 @@ Adopt a layered testing strategy:
 - **Adapters (REST, JPA):** test-after using Spring's test slices (`@WebMvcTest`, `@DataJpaTest`) and Testcontainers for real-database integration tests.
 - **End-to-end / black box:** a small number of "happy path" tests through the public API.
 
-Follow the **test pyramid**: many unit tests, fewer integration tests, very few end-to-end. No coverage target — coverage incentivizes meaningless tests. Instead, every public method on a domain aggregate must have tests for at least: happy path, each invariant violated, and any edge case implied by the domain.
+Follow the **test pyramid**: many unit tests, fewer integration tests, very few end-to-end. Every public method on a domain aggregate must have tests for at least: happy path, each invariant violated, and any edge case implied by the domain.
 
 Stack:
 - **JUnit 5 (Jupiter)** — test framework
@@ -38,7 +38,7 @@ ADR-002 set the testing *strategy* (TDD on the domain, test-after on adapters, t
 
 - **Domain tests are plain JUnit 5 unit tests — no Spring context.** Value objects and aggregates are pure Java; no `@SpringBootTest` in the domain layer.
 - **Structure:** Arrange–Act–Assert, written as `// given / // when / // then`.
-- **Assertions:** AssertJ `assertThat` imported from `org.assertj.core.api.Assertions` (not `BDDAssertions`). For `BigDecimal`, `isEqualByComparingTo` for numeric equality and `isEqualTo` for value-object equality. Mock interaction (later, in application-service tests) uses BDDMockito `given`/`then` — keeping `then` for mocks and `assertThat` for values avoids the word collision.
+- **Assertions:** AssertJ `assertThat` imported from `org.assertj.core.api.Assertions` (not `BDDAssertions`). For `BigDecimal`, `isEqualByComparingTo` for numeric equality and `isEqualTo` for value-object equality. Mock interaction (in application-service tests) uses BDDMockito `given`/`then` — keeping `then` for mocks and `assertThat` for values avoids the word collision.
 - **Naming:** behaviour-revealing method names (`should_<expected>_when_<condition>`), with `@DisplayName` carrying the full sentence; the method name need not duplicate it.
 - **Parameterized tests** (`@ParameterizedTest` + `@CsvSource`) for tabular cases (e.g. rounding), including the cases that *distinguish* the policy (HALF_EVEN vs HALF_UP).
 - **Tests must be able to fail:** choose inputs that would break if the behaviour were absent (a scale-0 normalisation test needs a non-zero-scale input).

--- a/docs/adr/0005-specific-identification-cost-basis.md
+++ b/docs/adr/0005-specific-identification-cost-basis.md
@@ -31,16 +31,17 @@ Adopt **Specific Identification cost basis with per-acquisition dividend attribu
 Acquisition (entity, immutable on creation)
 ├─ id
 ├─ portfolioId
-├─ symbol
+├─ assetId
 ├─ openDate
 ├─ openPrice
 ├─ openFee
-├─ initialQuantity              ← original, never changes
-├─ remainingQuantity (derived)  ← initialQuantity − Σ sell allocations against this acquisition
-└─ status (derived)             ← OPEN | PARTIALLY_CLOSED | CLOSED
+├─ initialQuantity                      ← original, never changes
+├─ remainingQuantity (derived)          ← initialQuantity − Σ sell allocations against this Acquisition
+├─ status (derived)                     ← OPEN | PARTIALLY_CLOSED | CLOSED
+└─ dividendAllocations: List<DividendAllocation>
 ```
 
-Each Buy creates exactly one Acquisition. A Acquisition is never mutated after creation; its lifecycle progresses through Sell allocations that reference it.
+Each Buy creates exactly one Acquisition. An Acquisition is never mutated after creation; its lifecycle progresses through Sell allocations and Dividend allocations that reference it.
 
 ### Sell model
 
@@ -50,9 +51,10 @@ A `Sell` is one transaction at one market price, possibly consuming from multipl
 Sell (entity)
 ├─ id
 ├─ portfolioId
-├─ symbol
+├─ assetId
 ├─ date
-├─ pricePerShare
+├─ price
+├─ totalQuantity
 ├─ totalFee
 └─ allocations: List<SellAllocation>
 
@@ -65,7 +67,7 @@ SellAllocation (value object)
 Invariants:
 - The sum of `sharesSoldFromAcquisition` across allocations equals the Sell's total quantity.
 - Each `SellAllocation.sharesSoldFromAcquisition ≤ targetAcquisition.remainingQuantity` at the time the Sell is recorded.
-- Fee is allocated proportionally to shares. Algebraically: `feeAllocated = totalFee × (sharesSoldFromAcquisition / totalShares)`, which equals `sharesSoldFromAcquisition × pricePerShare × sellRate` — so proportional is mathematically consistent with the underlying broker fee formula.
+- Fee is allocated proportionally to shares. Algebraically: `feeAllocated = totalFee × (sharesSoldFromAcquisition / totalQuantity)`, which equals `sharesSoldFromAcquisition × price × sellRate` — so proportional is mathematically consistent with the underlying broker fee formula.
 
 ### Dividend attribution
 

--- a/docs/adr/0009-domain-persistence-separation.md
+++ b/docs/adr/0009-domain-persistence-separation.md
@@ -34,7 +34,7 @@ Hexagonal structure is unaffected: the repository remains an outbound port; only
 - **(A) Merge — the domain entities *are* the JPA entities.** Mutable `@Entity` classes, mutation funnelled through aggregate methods, no public setters; value objects as `@Embeddable`.
   - Pros: no mapper; far less code; it is the mainstream Hibernate practice; faster to ship.
   - Cons: forces abandoning the sealed-record `Transaction` hierarchy and `Acquisition` immutability — the exact Java 21 design ADR-005/008 adopted as a deliberate correctness and clarity aid. Imports persistence concerns into the domain; "immutable on creation" degrades from a compiler guarantee to a discipline convention (protected setters for Hibernate).
-  - Why rejected (for Fintrackr): the sealed/record design is a deliberate part of the model's correctness and clarity. The cost of separation is bounded here — Fintrackr has essentially one rich aggregate (Portfolio, with its acquisitions, allocations, and ledger); BrokerAccount is small and Asset Catalog is in-memory in v1 — so the mapper is not pervasive ceremony. Merge will instead be tried deliberately on **Petalytics**, to experience the contrast first-hand.
+  - Why rejected (for Fintrackr): the sealed/record design is a deliberate part of the model's correctness and clarity. The cost of separation is bounded here — Fintrackr has essentially one rich aggregate (Portfolio, with its acquisitions, allocations, and ledger); BrokerAccount is small and Asset Catalog is in-memory in v1 — so the mapper is not pervasive ceremony.
 
 - **(B) Drop records; make the domain mutable, JPA-friendly classes.** A variant of merge that targets records specifically.
   - Pros: makes vanilla, spec-compliant JPA straightforward.

--- a/docs/adr/0010-module-package-structure-and-shared-kernel.md
+++ b/docs/adr/0010-module-package-structure-and-shared-kernel.md
@@ -19,7 +19,7 @@ Spring Modulith enforces module boundaries at build time, so this layout is not 
 
 - **Three context modules** as direct sub-packages of the application root: `portfolio`, `brokerage`, `catalog`. `catalog` is the short form of "Asset Catalog" and names the context's role (a reference-data registry), consistent with `portfolio` and `brokerage` naming areas rather than central entities.
 - **Hexagonal layout inside each context module:** `domain/model` (entities, value objects), `domain/...` (services, events as they appear), `application/port`, `infrastructure/adapter/...`.
-- **A fourth module, `shared`, holds the Shared Kernel:** value objects genuinely used by more than one context. v1 membership is **`Money` and `Symbol` only**. `Quantity` lives in `portfolio` (sole user); `Percentage` lives in `brokerage` (fee rates only). The kernel is kept deliberately minimal.
+- **A fourth module, `shared`, holds the Shared Kernel:** value objects genuinely used by more than one context. v1 membership is **`Money` and `AssetId` only**. `Quantity` lives in `portfolio` (sole user); `Percentage` lives in `brokerage` (fee rates only). The kernel is kept deliberately minimal.
 - **`shared` is laid out flat** (value objects directly under it), NOT mirroring `domain/model`. A kernel has a single concern (value types) and no application/infrastructure tiers; the hexagonal nesting would advertise layers that will never exist there.
 - **`shared` is realized as a Spring Modulith open module** (`@ApplicationModule(type = OPEN)`) and/or registered globally (`@Modulithic(sharedModules = "shared")`), so every context may depend on it even once explicit allowed-dependency whitelists are introduced.
 - **Dependency directions** (per ADR-003) are unchanged: Portfolio Management → Brokerage and → Asset Catalog through published APIs; never the reverse. `shared` is depended upon by all and depends on nothing.
@@ -51,11 +51,6 @@ Spring Modulith enforces module boundaries at build time, so this layout is not 
     - Cons: each is used by exactly one context; sharing over-exposes single-context types and invites accidental cross-context use.
     - Why rejected: keep the kernel to what is *actually* shared.
 
-- **Option F — own `Symbol` in `catalog`, expose via a named interface (Published Language) instead of the kernel.**
-    - Pros: catalog is the context that knows which symbols exist; arguably its identity concept.
-    - Cons: `Symbol` is a behaviourless, format-validated identifier used pervasively in Portfolio; depending on the whole Catalog module just for the type is heavier than the kernel.
-    - Why rejected (for now): placed in the kernel; revisit if Catalog grows behaviour around `Symbol`.
-
 ## Consequences
 
 ### Positive
@@ -70,7 +65,6 @@ Spring Modulith enforces module boundaries at build time, so this layout is not 
 
 ### Neutral / Open Questions
 - Whether `shared` uses `type = OPEN`, `@Modulithic(sharedModules)`, or per-module `allowedDependencies` — decided when the `ApplicationModules.verify()` test is added (not mutually exclusive).
-- `Symbol`'s home (kernel vs Catalog published language) — kernel for now.
 - A future net-worth / `CashAccount` abstraction (ADR-006) does NOT belong in `shared` if it lands — it is a read-model concern.
 
 ## References

--- a/docs/domain/domain-model.md
+++ b/docs/domain/domain-model.md
@@ -125,7 +125,7 @@ sealed interface Transaction
 | Subtype | Attributes                                                                                                        |
 |---|-------------------------------------------------------------------------------------------------------------------|
 | `Buy` | id, portfolioId, assetId, date, quantity, price, fee, acquisitionId (the Acquisition it opened)                   |
-| `Sell` | id, portfolioId, assetId, date, pricePerShare, totalFee, allocations: List\<SellAllocation\>                      |
+| `Sell` | id, portfolioId, assetId, date, price, totalQuantity, totalFee, allocations: List\<SellAllocation\>                      |
 | `Dividend` | id, portfolioId, assetId, cumDate, paymentDate, dps (dividend per share), allocations: List\<DividendAllocation\> |
 | `Deposit` | id, portfolioId, amount, date, source (e.g., "RDN")                                                               |
 | `Withdrawal` | id, portfolioId, amount, date, destination                                                                        |
@@ -178,14 +178,14 @@ Each Portfolio has a `defaultAcquisitionSelectionStrategy`. Every `recordSell` c
 
 All in business language. Each enforces its invariants internally before changing state.
 
-| Method                                                             | Purpose |
-|--------------------------------------------------------------------|---|
+| Method                                                             | Purpose                                                                                                                                                                                                                                                                                             |
+|--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `recordBuy(assetId, quantity, price, fee, date)`                   | Opens a new Acquisition; updates Holding cache; decrements tradingBalance; **returns the cash delta moved (`quantity × price + fee` as `Money`)** so the orchestrating app service applies that exact value to RDN (single source of truth — no recomputation, no drift); emits `BuyRecorded` event |
-| `recordSell(assetId, quantity, pricePerShare, fee, date, strategy)` | Resolves allocations via strategy; validates against open Acquisitions; updates referenced Acquisitions (derived state changes); updates Holding cache; increments tradingBalance; emits `SellRecorded` event |
-| `recordDividend(assetId, dps, cumDate, paymentDate)`                | For every eligible Acquisition of `symbol`, appends a DividendAllocation; increments tradingBalance; emits `DividendReceived` event |
-| `recordDeposit(amount, date, source)`                              | Increments tradingBalance from external cash inflow; emits `DepositRecorded` |
-| `recordWithdrawal(amount, date, destination)`                      | Decrements tradingBalance; emits `WithdrawalRecorded` |
-| `transferTo(targetPortfolioId, amount, date)`                      | Moves cash between portfolios under the same broker (preserves RDN total) |
+| `recordSell(assetId, quantity, pricePerShare, fee, date, strategy)` | Resolves allocations via strategy; validates against open Acquisitions; updates referenced Acquisitions (derived state changes); updates Holding cache; increments tradingBalance; emits `SellRecorded` event                                                                                       |
+| `recordDividend(assetId, dps, cumDate, paymentDate)`                | For every eligible Acquisition of `assetId`, appends a DividendAllocation; increments tradingBalance; emits `DividendReceived` event                                                                                                                                                                |
+| `recordDeposit(amount, date, source)`                              | Increments tradingBalance from external cash inflow; emits `DepositRecorded`                                                                                                                                                                                                                        |
+| `recordWithdrawal(amount, date, destination)`                      | Decrements tradingBalance; emits `WithdrawalRecorded`                                                                                                                                                                                                                                               |
+| `transferTo(targetPortfolioId, amount, date)`                      | Moves cash between portfolios under the same broker (preserves RDN total)                                                                                                                                                                                                                           |
 
 ### 4.5 Domain events emitted
 
@@ -241,7 +241,7 @@ FeeStructure (value object)
 
 Reference data. Lightweight in v1.
 
-### 6.1 Aggregate: `Asset` (sealed hierarchy — see future ADR-006)
+### 6.1 Aggregate: `Asset` (sealed hierarchy — see ADR-006)
 
 ```java
 sealed interface Asset permits Stock, MutualFund {

--- a/src/test/java/com/budiyanto/fintrackr/TestcontainersConfiguration.java
+++ b/src/test/java/com/budiyanto/fintrackr/TestcontainersConfiguration.java
@@ -12,7 +12,7 @@ class TestcontainersConfiguration {
     @Bean
     @ServiceConnection
     PostgreSQLContainer<?> postgresContainer() {
-        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"));
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:18-alpine"));
     }
 
 }


### PR DESCRIPTION
## Summary
- Catches the prose up to ADR-012 (AssetId = ISIN), which earlier sessions had decided but not propagated through the older documents
- No behavior or code change — documentation consistency only

## What changed
- `docs/adr/0002-testing-strategy.md` — minor wording (drop the coverage-target aside; BDDMockito note no longer says "later")
- `docs/adr/0005-specific-identification-cost-basis.md` — rename `symbol` to `assetId` in the Acquisition and Sell sketches; Sell now carries `price` + `totalQuantity` (was `pricePerShare`); add `dividendAllocations` to the Acquisition; fix fee-allocation formula to use `totalQuantity`
- - `docs/adr/0009-domain-persistence-separation.md` — trim a trailing Petalytics aside from the rejected-merge rationale
- `docs/adr/0010-module-package-structure-and-shared-kernel.md` — shared kernel membership is now `Money` + `AssetId` (was `Symbol`); remove the retracted "Option F / Symbol home" discussion and its open question
- `docs/domain/domain-model.md` — `Sell` subtype gains `price` + `totalQuantity`; `recordDividend` and method-table wording use `assetId`; ADR-006 reference de-stubbed