### PR TITLE
test: pin Postgres Testcontainers image to 18-alpine

### DIFF
--- a/src/test/java/com/budiyanto/fintrackr/TestcontainersConfiguration.java
+++ b/src/test/java/com/budiyanto/fintrackr/TestcontainersConfiguration.java
@@ -12,7 +12,7 @@ class TestcontainersConfiguration {
     @Bean
     @ServiceConnection
     PostgreSQLContainer<?> postgresContainer() {
-        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"));
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:18-alpine"));
     }
 
 }


### PR DESCRIPTION
## Summary
- Pins the integration-test database image instead of tracking `postgres:latest`, so the test environment is reproducible
- A floating `:latest` tag makes builds non-deterministic and can break CI when upstream publishes a new major; `alpine` also pulls faster

## What changed
- `TestcontainersConfiguration.java` — `postgres:latest` → `postgres:18-alpine`