### PR TITLE
feat(portfolio): record deposits with balance, amount, and date invariants

### DIFF
--- a/src/main/java/com/budiyanto/fintrackr/FintrackrApplication.java
+++ b/src/main/java/com/budiyanto/fintrackr/FintrackrApplication.java
@@ -2,8 +2,10 @@ package com.budiyanto.fintrackr;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.modulith.Modulithic;
 
 @SpringBootApplication
+@Modulithic(sharedModules = "shared")
 public class FintrackrApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/Percentage.java
+++ b/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/Percentage.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 public record Percentage(BigDecimal rate) {
 
     public Percentage {
-        Objects.requireNonNull(rate, "Percentage rate must not be null");
+        Objects.requireNonNull(rate, "Percentage rate cannot be null");
         if (rate.compareTo(BigDecimal.ZERO) < 0 || rate.compareTo(BigDecimal.ONE) > 0) {
             throw new IllegalArgumentException("Percentage rate must be between 0 and 1, inclusive");
         }

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/FutureDatedTransactionException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/FutureDatedTransactionException.java
@@ -1,0 +1,12 @@
+package com.budiyanto.fintrackr.portfolio.domain.exception;
+
+import com.budiyanto.fintrackr.shared.DomainException;
+
+import java.time.LocalDate;
+
+public class FutureDatedTransactionException extends DomainException {
+
+    public FutureDatedTransactionException(LocalDate date, LocalDate today) {
+        super("Future dated transaction is not allowed. Date: " + date + ", Today: " + today + ".");
+    }
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/NonPositiveAmountException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/NonPositiveAmountException.java
@@ -1,0 +1,12 @@
+package com.budiyanto.fintrackr.portfolio.domain.exception;
+
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+
+public class NonPositiveAmountException extends DomainException {
+
+    public NonPositiveAmountException(Money amount) {
+        super("Non positive amount is not allowed: " + amount.amount());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
@@ -1,0 +1,47 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import com.budiyanto.fintrackr.portfolio.domain.exception.FutureDatedTransactionException;
+import com.budiyanto.fintrackr.portfolio.domain.exception.NonPositiveAmountException;
+import com.budiyanto.fintrackr.shared.BrokerAccountId;
+import com.budiyanto.fintrackr.shared.Money;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public class Portfolio {
+
+    private final PortfolioId portfolioId;
+    private final BrokerAccountId brokerAccountId;
+    private String name;
+    private Money tradingBalance;
+
+    private Portfolio (BrokerAccountId brokerAccountId, String name) {
+        this.portfolioId = PortfolioId.generate();
+        this.brokerAccountId = brokerAccountId;
+        this.name = name;
+        this.tradingBalance = Money.zero();
+    }
+
+    public static Portfolio create(BrokerAccountId brokerAccountId, String name) {
+        return new Portfolio(brokerAccountId, name);
+    }
+
+    public void recordDeposit(Money amount, LocalDate date, LocalDate today) {
+        Objects.requireNonNull(amount, "amount cannot be null");
+        Objects.requireNonNull(date, "date cannot be null");
+        Objects.requireNonNull(today, "today cannot be null");
+
+        if (amount.isZeroOrNegative()) {
+            throw new NonPositiveAmountException(amount);
+        }
+
+        if (date.isAfter(today)) {
+            throw new FutureDatedTransactionException(date, today);
+        }
+
+        tradingBalance = tradingBalance.add(amount);
+    }
+
+    public Money tradingBalance() { return tradingBalance; }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioId.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioId.java
@@ -1,0 +1,16 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record PortfolioId(UUID value) {
+
+    public PortfolioId {
+        Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    public static PortfolioId generate() {
+        return new PortfolioId(UUID.randomUUID());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Quantity.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Quantity.java
@@ -9,7 +9,7 @@ public class Quantity {
     private final BigDecimal value;
 
     private Quantity(BigDecimal value) {
-        Objects.requireNonNull(value, "Quantity value must not be null");
+        Objects.requireNonNull(value, "Quantity value cannot be null");
         if (value.compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("Quantity value cannot be negative");
         }

--- a/src/main/java/com/budiyanto/fintrackr/shared/AssetId.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/AssetId.java
@@ -7,7 +7,8 @@ import java.util.Objects;
 public record AssetId(String value) {
 
     public AssetId {
-        Objects.requireNonNull(value);
+
+        Objects.requireNonNull(value, "Isin value cannot be null");
         if (value.isBlank()) {
             throw new IllegalArgumentException("Isin value cannot be blank");
         }

--- a/src/main/java/com/budiyanto/fintrackr/shared/BrokerAccountId.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/BrokerAccountId.java
@@ -1,0 +1,18 @@
+package com.budiyanto.fintrackr.shared;
+
+import org.springframework.validation.ObjectError;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record BrokerAccountId(UUID value) {
+
+    public BrokerAccountId {
+        Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    public static BrokerAccountId generate() {
+        return new BrokerAccountId(UUID.randomUUID());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/shared/DomainException.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/DomainException.java
@@ -1,0 +1,8 @@
+package com.budiyanto.fintrackr.shared;
+
+public abstract class DomainException extends RuntimeException {
+
+    public DomainException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/budiyanto/fintrackr/shared/Money.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/Money.java
@@ -5,7 +5,8 @@ import java.math.RoundingMode;
 import java.util.Currency;
 import java.util.Objects;
 
-public record Money(BigDecimal amount, Currency currency) {
+
+public record Money(BigDecimal amount, Currency currency) implements Comparable<Money> {
 
     public Money {
         Objects.requireNonNull(amount, "amount cannot be null");
@@ -15,5 +16,39 @@ public record Money(BigDecimal amount, Currency currency) {
 
     public static Money of(BigDecimal amount) {
         return new Money(amount, Currency.getInstance("IDR"));
+    }
+
+    public static Money zero() {
+        return new Money(BigDecimal.ZERO, Currency.getInstance("IDR"));
+    }
+
+    public Money add(Money toAdd) {
+        checkSameCurrency(toAdd);
+        return new Money(amount.add(toAdd.amount), currency);
+    }
+
+    @Override
+    public int compareTo(Money value) {
+        checkSameCurrency(value);
+        return amount.compareTo(value.amount);
+    }
+
+    public boolean isPositive() {
+        return compareTo(Money.zero()) > 0;
+    }
+
+    public boolean isNegative() {
+        return compareTo(Money.zero()) < 0;
+    }
+
+    public boolean isZeroOrNegative() {
+        return compareTo(Money.zero()) <= 0;
+    }
+
+    private void checkSameCurrency(Money value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        if (!currency.equals(value.currency)) {
+            throw new IllegalArgumentException("The input currency is not equal to currency");
+        }
     }
 }

--- a/src/test/java/com/budiyanto/fintrackr/ApplicationModulesTests.java
+++ b/src/test/java/com/budiyanto/fintrackr/ApplicationModulesTests.java
@@ -1,0 +1,15 @@
+package com.budiyanto.fintrackr;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.modulith.core.ApplicationModules;
+
+class ApplicationModulesTests {
+
+    private final ApplicationModules modules = ApplicationModules.of(FintrackrApplication.class);
+
+    @Test
+    void verifyModularStructure() {
+        modules.verify();
+    }
+
+}

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioTest.java
@@ -1,0 +1,145 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import com.budiyanto.fintrackr.portfolio.domain.exception.FutureDatedTransactionException;
+import com.budiyanto.fintrackr.portfolio.domain.exception.NonPositiveAmountException;
+import com.budiyanto.fintrackr.shared.BrokerAccountId;
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+
+import net.bytebuddy.asm.Advice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Portfolio Tests")
+class PortfolioTest {
+
+    private Portfolio portfolio;
+    private LocalDate date;
+    private LocalDate today;
+
+    @BeforeEach
+    void setup() {
+        portfolio = Portfolio.create(BrokerAccountId.generate(), "Long-Term");
+        date = LocalDate.of(2026, 6, 20);
+        today = LocalDate.of(2026, 6, 28);
+    }
+
+    @Nested
+    @DisplayName("RecordDeposit Tests")
+    class RecordDeposit {
+
+        // Happy Path
+        @Test
+        @DisplayName("Increase the trading balance when a single deposit is correctly recorded")
+        void should_increaseTradingBalance_when_recordDeposit() {
+            // Given
+            Money amount = Money.of(new BigDecimal("1000"));
+
+            // When
+            portfolio.recordDeposit(amount, date, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(amount);
+        }
+
+        @Test
+        @DisplayName("Accumulate the trading balance when multiple deposits are correctly recorded")
+        void should_accumulateTradingBalance_when_recordMultipleDeposits() {
+            // Given
+            Money amount1 = Money.of(new BigDecimal(1500));
+            Money amount2 = Money.of(new BigDecimal(2000));
+            Money amount3 = Money.of(new BigDecimal(3500));
+
+            // When
+            portfolio.recordDeposit(amount1, date, today);
+            portfolio.recordDeposit(amount2, date, today);
+            portfolio.recordDeposit(amount3, date, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(Money.of(new BigDecimal(7000)));
+        }
+
+        @Test
+        @DisplayName("Allow deposit when date is today")
+        void should_allowDeposit_when_dateIsToday() {
+            // Given
+            Money amount = Money.of(new BigDecimal("15000"));
+
+            // When
+            portfolio.recordDeposit(amount, today, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(amount);
+        }
+
+        @Test
+        @DisplayName("Record a Deposit transaction when a deposit is correctly recorded")
+        @Disabled("not yet implemented")
+        void should_recordDepositTransaction_when_recordDeposit() {
+
+        }
+
+        // Invariant Violations
+        @ParameterizedTest
+        @ValueSource(strings = {"0", "-1500"})
+        @DisplayName("Reject a deposit when the amount is zero or negative")
+        void should_throwException_when_amountLessThanOrEqualZero(String input) {
+            // Given
+            Money amount = Money.of(new BigDecimal(input));
+
+            // When & Then
+            assertThatThrownBy(() -> portfolio.recordDeposit(amount, date, today))
+                    .isInstanceOf(NonPositiveAmountException.class);
+        }
+
+        @Test
+        @DisplayName("Reject a deposit when the date is in the future")
+        void should_throwException_when_dateInFuture() {
+            // Given
+            Money amount = Money.of(new BigDecimal("1000"));
+            LocalDate futureDate = LocalDate.of(2026, 12, 15);
+
+            // When & Then
+            assertThatThrownBy(() -> portfolio.recordDeposit(amount, futureDate, today))
+                    .isInstanceOf(FutureDatedTransactionException.class);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "-15000, 2026-06-01",
+                "20000, 2026-12-15"
+        })
+        @DisplayName("Keep balance unchanged when deposit is rejected")
+        void should_leaveBalanceUnchanged_when_depositRejected(String amount, LocalDate depositDate) {
+            // Given
+            Money firstDeposit = Money.of(new BigDecimal("10000"));
+            Money secondDeposit = Money.of(new BigDecimal(amount));
+            LocalDate validDate = LocalDate.of(2026, 6, 1);
+
+            portfolio.recordDeposit(firstDeposit, validDate, today);
+            Money balanceBefore = portfolio.tradingBalance();
+
+            // When
+            assertThatThrownBy(() -> portfolio.recordDeposit(secondDeposit, depositDate, today))
+                    .isInstanceOf(DomainException.class);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(balanceBefore);
+        }
+
+
+    }
+
+}

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/QuantityTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/QuantityTest.java
@@ -2,7 +2,6 @@ package com.budiyanto.fintrackr.portfolio.domain.model;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;


### PR DESCRIPTION
## Summary
- Adds `Portfolio.recordDeposit(amount, date, today)`, the first aggregate business method: it guards its inputs, then increases `tradingBalance`
- Enforces three invariants in the domain, not a service: non-null args, amount must be positive, and no future-dated transactions
- Introduces the exception hierarchy from ADR-011 (base in `shared`, subtypes in the owning module) and marks `shared` as a Spring Modulith shared module with an `ApplicationModules.verify()` guard test
- Cash is not yet written to a transaction ledger; the `Deposit` ledger entry and `Transaction` sealed hierarchy are the next unit of work

## What changed
- `Portfolio.java` (new) — aggregate root with a `create` factory and `recordDeposit`; validates before it mutates
- `PortfolioId.java` (new) — typed identity, `generate()` factory, minted in the factory (ADR-009 keeps domain ids independent of the DB)
- `shared/BrokerAccountId.java` (new) — cross-context identity promoted to the kernel (referenced by both `brokerage` and `portfolio`)
- `shared/DomainException.java` (new) — abstract unchecked base (ADR-011)
- `portfolio/domain/exception/NonPositiveAmountException.java`, `FutureDatedTransactionException.java` (new) — domain rule violations
- `shared/Money.java` — currency-safe `add`, `compareTo` (`implements Comparable<Money>`), and `isPositive`/`isNegative`/
  `isZeroOrNegative` helpers; canonical scale keeps equality scale-safe
- `FintrackrApplication.java` — `@SpringBootApplication` + `@Modulithic(sharedModules = "shared")`
- `ApplicationModulesTests.java` (new) — `modules.verify()` boundary guard
- `PortfolioTest.java` (new) — happy path, accumulation, boundary (date == today), and rejection tests incl. state-unchanged-on-rejection
- `Percentage.java`, `Quantity.java`, `AssetId.java` — null-guard message wording aligned to the `"... cannot be null"` convention; dead import dropped from `QuantityTest.java`

## Test plan
- [x] Single deposit increases trading balance
- [x] Multiple deposits accumulate
- [x] Deposit dated today (boundary) is accepted
- [x] Amount <= 0 rejected with `NonPositiveAmountException`
- [x] Future-dated deposit rejected with `FutureDatedTransactionException`
- [x] Rejected deposit leaves trading balance unchanged
- [x] `ApplicationModules.verify()` green (module boundaries hold)