### PR TITLE
docs(adr): resolve Modulith shared-module and DomainException-home ADR questions

### DIFF
--- a/docs/adr/0010-module-package-structure-and-shared-kernel.md
+++ b/docs/adr/0010-module-package-structure-and-shared-kernel.md
@@ -19,9 +19,9 @@ Spring Modulith enforces module boundaries at build time, so this layout is not 
 
 - **Three context modules** as direct sub-packages of the application root: `portfolio`, `brokerage`, `catalog`. `catalog` is the short form of "Asset Catalog" and names the context's role (a reference-data registry), consistent with `portfolio` and `brokerage` naming areas rather than central entities.
 - **Hexagonal layout inside each context module:** `domain/model` (entities, value objects), `domain/...` (services, events as they appear), `application/port`, `infrastructure/adapter/...`.
-- **A fourth module, `shared`, holds the Shared Kernel:** value objects genuinely used by more than one context. v1 membership is **`Money` and `AssetId` only**. `Quantity` lives in `portfolio` (sole user); `Percentage` lives in `brokerage` (fee rates only). The kernel is kept deliberately minimal.
+- **A fourth module, `shared`, holds the Shared Kernel:** behaviourless value and identity types genuinely used by more than one context. v1 membership is **`Money`, `AssetId`, and `BrokerAccountId`**. `Quantity` lives in `portfolio` (sole user); `Percentage` lives in `brokerage` (fee rates only); `PortfolioId` lives in `portfolio` (no other context references it yet). The kernel is kept deliberately minimal: **a typed identifier is promoted here only once a second module references it** — `AssetId` (Catalog ↔ Portfolio) and `BrokerAccountId` (Brokerage ↔ Portfolio) qualify; `PortfolioId` does not, yet.
 - **`shared` is laid out flat** (value objects directly under it), NOT mirroring `domain/model`. A kernel has a single concern (value types) and no application/infrastructure tiers; the hexagonal nesting would advertise layers that will never exist there.
-- **`shared` is realized as a Spring Modulith open module** (`@ApplicationModule(type = OPEN)`) and/or registered globally (`@Modulithic(sharedModules = "shared")`), so every context may depend on it even once explicit allowed-dependency whitelists are introduced.
+- **`shared` is registered globally as a shared module** via `@Modulithic(sharedModules = "shared")` on the application class (Session 10), so every context may depend on it even once explicit allowed-dependency whitelists are introduced. `type = OPEN` was considered and rejected: `shared` is laid out flat, so it has no internal sub-packages to expose; and it is `sharedModules` — not `OPEN` — that exempts a kernel from per-module dependency whitelists.
 - **Dependency directions** (per ADR-003) are unchanged: Portfolio Management → Brokerage and → Asset Catalog through published APIs; never the reverse. `shared` is depended upon by all and depends on nothing.
 
 ## Alternatives Considered
@@ -33,7 +33,7 @@ Spring Modulith enforces module boundaries at build time, so this layout is not 
 
 - **Option B — duplicate the VOs per context.**
     - Pros: full module autonomy.
-    - Cons: `Money`/`Symbol` are identical everywhere; duplication yields non-interoperable types (a Brokerage `Money` cannot be compared to a Portfolio `Money`) and drift risk.
+    - Cons: `Money`/`AssetId` are identical everywhere; duplication yields non-interoperable types (a Brokerage `Money` cannot be compared to a Portfolio `Money`) and drift risk.
     - Why rejected: duplication is a service-boundary technique, not for in-process modules sharing an identical concept.
 
 - **Option C — a `common`/`utils` module instead of a curated `shared` kernel.**
@@ -51,7 +51,11 @@ Spring Modulith enforces module boundaries at build time, so this layout is not 
     - Cons: each is used by exactly one context; sharing over-exposes single-context types and invites accidental cross-context use.
     - Why rejected: keep the kernel to what is *actually* shared.
 
-## Consequences
+- **Option F — keep cross-context identifiers in their owning context and expose them via a Spring Modulith named interface (Published Language), instead of the kernel.**
+    - Applies to `AssetId` (owned by `catalog`) and `BrokerAccountId` (owned by `brokerage`), each referenced by Portfolio Management.
+    - Pros: identity stays with the aggregate that owns it; the kernel stays smaller; each module's published surface is explicit.
+    - Cons: these are behaviourless, format/null-validated identifiers referenced across modules; a `@NamedInterface` per identifier is more ceremony, and depending on a whole owning module just to reuse its id type is heavier than depending on a tiny kernel. Every module that later adopts an `allowedDependencies` whitelist would also have to list the owning module solely for the id.
+    - Why rejected: cross-context *identifiers* are exactly what the kernel is for — behaviourless types shared by more than one context. Placed in the kernel. Revisit per identifier if its owning context grows behaviour that the identifier should travel with.
 
 ### Positive
 - Dependency directions stay clean and Spring-Modulith-enforceable; the kernel has zero outbound dependencies.
@@ -60,11 +64,12 @@ Spring Modulith enforces module boundaries at build time, so this layout is not 
 - Extraction-friendly: if a context is later split into a service, the kernel is already isolated (copy it, or publish it as a contract).
 
 ### Negative (costs we explicitly accept)
-- A shared kernel is, by definition, the highest-coupling area: changes to `Money`/`Symbol` ripple to all contexts. Mitigated by keeping it tiny and stable.
+- A shared kernel is, by definition, the highest-coupling area: changes to `Money`/`AssetId` ripple to all contexts. Mitigated by keeping it tiny and stable.
 - `shared` is laid out differently from the context modules — a deliberate, honest inconsistency.
 
 ### Neutral / Open Questions
-- Whether `shared` uses `type = OPEN`, `@Modulithic(sharedModules)`, or per-module `allowedDependencies` — decided when the `ApplicationModules.verify()` test is added (not mutually exclusive).
+- ~~Whether `shared` uses `type = OPEN`, `@Modulithic(sharedModules)`, or per-module `allowedDependencies`~~ — RESOLVED (Session 10): `@Modulithic(sharedModules = "shared")`; no `allowedDependencies` whitelists yet. `shared` also hosts the cross-cutting `DomainException` base (behaviour, not a value type — a deliberate stretch of the kernel charter; see ADR-011).
+- Cross-context identifiers' home (kernel vs owning-context published language) — kernel for now (`AssetId`, `BrokerAccountId`); revisit per identifier if its owning context grows behaviour around it.
 - A future net-worth / `CashAccount` abstraction (ADR-006) does NOT belong in `shared` if it lands — it is a read-model concern.
 
 ## References

--- a/docs/adr/0011-exception-strategy.md
+++ b/docs/adr/0011-exception-strategy.md
@@ -55,7 +55,7 @@ The system produces two very different kinds of failure: low-level **preconditio
 ### Neutral / Open Questions
 - Exact `ProblemDetail` mapping (status codes, error codes, i18n) — when the REST adapter is built.
 - Whether VO format violations join the domain hierarchy — open.
-- Where `DomainException` lives — likely a small cross-cutting home (possibly `shared`, though it is behaviour, not a value object) — decided when introduced.
+- ~~Where `DomainException` lives~~ — RESOLVED (Session 10): the abstract base lives in `shared` (the only module every context may depend on); concrete subtypes live in their owning module (e.g. `portfolio.domain.exception.NonPositiveAmountException`, `FutureDatedTransactionException`). The base is behaviour, not a value object — a deliberate, documented stretch of `shared`'s charter (cross-referenced in ADR-010).
 
 ## References
 - ADR-002 (testing — assert by type)

--- a/src/main/java/com/budiyanto/fintrackr/FintrackrApplication.java
+++ b/src/main/java/com/budiyanto/fintrackr/FintrackrApplication.java
@@ -2,8 +2,10 @@ package com.budiyanto.fintrackr;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.modulith.Modulithic;
 
 @SpringBootApplication
+@Modulithic(sharedModules = "shared")
 public class FintrackrApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/Percentage.java
+++ b/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/Percentage.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 public record Percentage(BigDecimal rate) {
 
     public Percentage {
-        Objects.requireNonNull(rate, "Percentage rate must not be null");
+        Objects.requireNonNull(rate, "Percentage rate cannot be null");
         if (rate.compareTo(BigDecimal.ZERO) < 0 || rate.compareTo(BigDecimal.ONE) > 0) {
             throw new IllegalArgumentException("Percentage rate must be between 0 and 1, inclusive");
         }

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/FutureDatedTransactionException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/FutureDatedTransactionException.java
@@ -1,0 +1,12 @@
+package com.budiyanto.fintrackr.portfolio.domain.exception;
+
+import com.budiyanto.fintrackr.shared.DomainException;
+
+import java.time.LocalDate;
+
+public class FutureDatedTransactionException extends DomainException {
+
+    public FutureDatedTransactionException(LocalDate date, LocalDate today) {
+        super("Future dated transaction is not allowed. Date: " + date + ", Today: " + today + ".");
+    }
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/NonPositiveAmountException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/NonPositiveAmountException.java
@@ -1,0 +1,12 @@
+package com.budiyanto.fintrackr.portfolio.domain.exception;
+
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+
+public class NonPositiveAmountException extends DomainException {
+
+    public NonPositiveAmountException(Money amount) {
+        super("Non positive amount is not allowed: " + amount.amount());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
@@ -1,0 +1,47 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import com.budiyanto.fintrackr.portfolio.domain.exception.FutureDatedTransactionException;
+import com.budiyanto.fintrackr.portfolio.domain.exception.NonPositiveAmountException;
+import com.budiyanto.fintrackr.shared.BrokerAccountId;
+import com.budiyanto.fintrackr.shared.Money;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public class Portfolio {
+
+    private final PortfolioId portfolioId;
+    private final BrokerAccountId brokerAccountId;
+    private String name;
+    private Money tradingBalance;
+
+    private Portfolio (BrokerAccountId brokerAccountId, String name) {
+        this.portfolioId = PortfolioId.generate();
+        this.brokerAccountId = brokerAccountId;
+        this.name = name;
+        this.tradingBalance = Money.zero();
+    }
+
+    public static Portfolio create(BrokerAccountId brokerAccountId, String name) {
+        return new Portfolio(brokerAccountId, name);
+    }
+
+    public void recordDeposit(Money amount, LocalDate date, LocalDate today) {
+        Objects.requireNonNull(amount, "amount cannot be null");
+        Objects.requireNonNull(date, "date cannot be null");
+        Objects.requireNonNull(today, "today cannot be null");
+
+        if (amount.isZeroOrNegative()) {
+            throw new NonPositiveAmountException(amount);
+        }
+
+        if (date.isAfter(today)) {
+            throw new FutureDatedTransactionException(date, today);
+        }
+
+        tradingBalance = tradingBalance.add(amount);
+    }
+
+    public Money tradingBalance() { return tradingBalance; }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioId.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioId.java
@@ -1,0 +1,16 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record PortfolioId(UUID value) {
+
+    public PortfolioId {
+        Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    public static PortfolioId generate() {
+        return new PortfolioId(UUID.randomUUID());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Quantity.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Quantity.java
@@ -9,7 +9,7 @@ public class Quantity {
     private final BigDecimal value;
 
     private Quantity(BigDecimal value) {
-        Objects.requireNonNull(value, "Quantity value must not be null");
+        Objects.requireNonNull(value, "Quantity value cannot be null");
         if (value.compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("Quantity value cannot be negative");
         }

--- a/src/main/java/com/budiyanto/fintrackr/shared/AssetId.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/AssetId.java
@@ -7,7 +7,8 @@ import java.util.Objects;
 public record AssetId(String value) {
 
     public AssetId {
-        Objects.requireNonNull(value);
+
+        Objects.requireNonNull(value, "Isin value cannot be null");
         if (value.isBlank()) {
             throw new IllegalArgumentException("Isin value cannot be blank");
         }

--- a/src/main/java/com/budiyanto/fintrackr/shared/BrokerAccountId.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/BrokerAccountId.java
@@ -1,0 +1,18 @@
+package com.budiyanto.fintrackr.shared;
+
+import org.springframework.validation.ObjectError;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record BrokerAccountId(UUID value) {
+
+    public BrokerAccountId {
+        Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    public static BrokerAccountId generate() {
+        return new BrokerAccountId(UUID.randomUUID());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/shared/DomainException.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/DomainException.java
@@ -1,0 +1,8 @@
+package com.budiyanto.fintrackr.shared;
+
+public abstract class DomainException extends RuntimeException {
+
+    public DomainException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/budiyanto/fintrackr/shared/Money.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/Money.java
@@ -5,7 +5,8 @@ import java.math.RoundingMode;
 import java.util.Currency;
 import java.util.Objects;
 
-public record Money(BigDecimal amount, Currency currency) {
+
+public record Money(BigDecimal amount, Currency currency) implements Comparable<Money> {
 
     public Money {
         Objects.requireNonNull(amount, "amount cannot be null");
@@ -15,5 +16,39 @@ public record Money(BigDecimal amount, Currency currency) {
 
     public static Money of(BigDecimal amount) {
         return new Money(amount, Currency.getInstance("IDR"));
+    }
+
+    public static Money zero() {
+        return new Money(BigDecimal.ZERO, Currency.getInstance("IDR"));
+    }
+
+    public Money add(Money toAdd) {
+        checkSameCurrency(toAdd);
+        return new Money(amount.add(toAdd.amount), currency);
+    }
+
+    @Override
+    public int compareTo(Money value) {
+        checkSameCurrency(value);
+        return amount.compareTo(value.amount);
+    }
+
+    public boolean isPositive() {
+        return compareTo(Money.zero()) > 0;
+    }
+
+    public boolean isNegative() {
+        return compareTo(Money.zero()) < 0;
+    }
+
+    public boolean isZeroOrNegative() {
+        return compareTo(Money.zero()) <= 0;
+    }
+
+    private void checkSameCurrency(Money value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        if (!currency.equals(value.currency)) {
+            throw new IllegalArgumentException("The input currency is not equal to currency");
+        }
     }
 }

--- a/src/test/java/com/budiyanto/fintrackr/ApplicationModulesTests.java
+++ b/src/test/java/com/budiyanto/fintrackr/ApplicationModulesTests.java
@@ -1,0 +1,15 @@
+package com.budiyanto.fintrackr;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.modulith.core.ApplicationModules;
+
+class ApplicationModulesTests {
+
+    private final ApplicationModules modules = ApplicationModules.of(FintrackrApplication.class);
+
+    @Test
+    void verifyModularStructure() {
+        modules.verify();
+    }
+
+}

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioTest.java
@@ -1,0 +1,145 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import com.budiyanto.fintrackr.portfolio.domain.exception.FutureDatedTransactionException;
+import com.budiyanto.fintrackr.portfolio.domain.exception.NonPositiveAmountException;
+import com.budiyanto.fintrackr.shared.BrokerAccountId;
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+
+import net.bytebuddy.asm.Advice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Portfolio Tests")
+class PortfolioTest {
+
+    private Portfolio portfolio;
+    private LocalDate date;
+    private LocalDate today;
+
+    @BeforeEach
+    void setup() {
+        portfolio = Portfolio.create(BrokerAccountId.generate(), "Long-Term");
+        date = LocalDate.of(2026, 6, 20);
+        today = LocalDate.of(2026, 6, 28);
+    }
+
+    @Nested
+    @DisplayName("RecordDeposit Tests")
+    class RecordDeposit {
+
+        // Happy Path
+        @Test
+        @DisplayName("Increase the trading balance when a single deposit is correctly recorded")
+        void should_increaseTradingBalance_when_recordDeposit() {
+            // Given
+            Money amount = Money.of(new BigDecimal("1000"));
+
+            // When
+            portfolio.recordDeposit(amount, date, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(amount);
+        }
+
+        @Test
+        @DisplayName("Accumulate the trading balance when multiple deposits are correctly recorded")
+        void should_accumulateTradingBalance_when_recordMultipleDeposits() {
+            // Given
+            Money amount1 = Money.of(new BigDecimal(1500));
+            Money amount2 = Money.of(new BigDecimal(2000));
+            Money amount3 = Money.of(new BigDecimal(3500));
+
+            // When
+            portfolio.recordDeposit(amount1, date, today);
+            portfolio.recordDeposit(amount2, date, today);
+            portfolio.recordDeposit(amount3, date, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(Money.of(new BigDecimal(7000)));
+        }
+
+        @Test
+        @DisplayName("Allow deposit when date is today")
+        void should_allowDeposit_when_dateIsToday() {
+            // Given
+            Money amount = Money.of(new BigDecimal("15000"));
+
+            // When
+            portfolio.recordDeposit(amount, today, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(amount);
+        }
+
+        @Test
+        @DisplayName("Record a Deposit transaction when a deposit is correctly recorded")
+        @Disabled("not yet implemented")
+        void should_recordDepositTransaction_when_recordDeposit() {
+
+        }
+
+        // Invariant Violations
+        @ParameterizedTest
+        @ValueSource(strings = {"0", "-1500"})
+        @DisplayName("Reject a deposit when the amount is zero or negative")
+        void should_throwException_when_amountLessThanOrEqualZero(String input) {
+            // Given
+            Money amount = Money.of(new BigDecimal(input));
+
+            // When & Then
+            assertThatThrownBy(() -> portfolio.recordDeposit(amount, date, today))
+                    .isInstanceOf(NonPositiveAmountException.class);
+        }
+
+        @Test
+        @DisplayName("Reject a deposit when the date is in the future")
+        void should_throwException_when_dateInFuture() {
+            // Given
+            Money amount = Money.of(new BigDecimal("1000"));
+            LocalDate futureDate = LocalDate.of(2026, 12, 15);
+
+            // When & Then
+            assertThatThrownBy(() -> portfolio.recordDeposit(amount, futureDate, today))
+                    .isInstanceOf(FutureDatedTransactionException.class);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "-15000, 2026-06-01",
+                "20000, 2026-12-15"
+        })
+        @DisplayName("Keep balance unchanged when deposit is rejected")
+        void should_leaveBalanceUnchanged_when_depositRejected(String amount, LocalDate depositDate) {
+            // Given
+            Money firstDeposit = Money.of(new BigDecimal("10000"));
+            Money secondDeposit = Money.of(new BigDecimal(amount));
+            LocalDate validDate = LocalDate.of(2026, 6, 1);
+
+            portfolio.recordDeposit(firstDeposit, validDate, today);
+            Money balanceBefore = portfolio.tradingBalance();
+
+            // When
+            assertThatThrownBy(() -> portfolio.recordDeposit(secondDeposit, depositDate, today))
+                    .isInstanceOf(DomainException.class);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(balanceBefore);
+        }
+
+
+    }
+
+}

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/QuantityTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/QuantityTest.java
@@ -2,7 +2,6 @@ package com.budiyanto.fintrackr.portfolio.domain.model;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;


### PR DESCRIPTION
## Summary
- Closes two open questions that Session 10's implementation settled; no code change, documentation consistency only
- ADR-010: `shared` is registered via `@Modulithic(sharedModules)`, no `type = OPEN`; records the kernel-promotion rule for typed identifiers
- ADR-011: the `DomainException` base lives in `shared`, subtypes in their owning module

## What changed
- `docs/adr/0010-module-package-structure-and-shared-kernel.md`:
  - Kernel membership is now `Money`, `AssetId`, `BrokerAccountId`; adds the rule "an identifier is promoted to the kernel only once a second module references it" (so `PortfolioId` stays in `portfolio`)
  - Realized-module bullet finalized to `@Modulithic(sharedModules)` with the reasoning for rejecting `type = OPEN` (flat layout, nothing to expose; `sharedModules` is what exempts a kernel from whitelists)
  - Restores Option F (named-interface vs kernel for cross-context ids) and resolves the open question; notes `shared` also hosts
    `DomainException`
  - Fixes stale `Symbol` references to `AssetId` in Option B and Negatives
- `docs/adr/0011-exception-strategy.md`:
  - Resolves "where `DomainException` lives": abstract base in `shared`, concrete subtypes in the owning module, cross-referenced to ADR-010
 
## Test plan
- [x] Docs only; no build or test impact