### PR TITLE
docs(domain): drop Deposit source and sync recordDeposit to the ledger

### DIFF
--- a/docs/domain/domain-model.md
+++ b/docs/domain/domain-model.md
@@ -127,7 +127,7 @@ sealed interface Transaction
 | `Buy` | id, portfolioId, assetId, date, quantity, price, fee, acquisitionId (the Acquisition it opened)                   |
 | `Sell` | id, portfolioId, assetId, date, price, totalQuantity, totalFee, allocations: List\<SellAllocation\>                      |
 | `Dividend` | id, portfolioId, assetId, cumDate, paymentDate, dps (dividend per share), allocations: List\<DividendAllocation\> |
-| `Deposit` | id, portfolioId, amount, date, source (e.g., "RDN")                                                               |
+| `Deposit` | id, portfolioId, amount, date  (v1: `source` dropped — deposits always originate from RDN, so it carried no information; reintroduce if a non-RDN cash source appears) |
 | `Withdrawal` | id, portfolioId, amount, date, destination                                                                        |
 
 All Transactions are immutable once recorded. Corrections are made by recording a reversing transaction, never by editing.
@@ -183,7 +183,7 @@ All in business language. Each enforces its invariants internally before changin
 | `recordBuy(assetId, quantity, price, fee, date)`                   | Opens a new Acquisition; updates Holding cache; decrements tradingBalance; **returns the cash delta moved (`quantity × price + fee` as `Money`)** so the orchestrating app service applies that exact value to RDN (single source of truth — no recomputation, no drift); emits `BuyRecorded` event |
 | `recordSell(assetId, quantity, pricePerShare, fee, date, strategy)` | Resolves allocations via strategy; validates against open Acquisitions; updates referenced Acquisitions (derived state changes); updates Holding cache; increments tradingBalance; emits `SellRecorded` event                                                                                       |
 | `recordDividend(assetId, dps, cumDate, paymentDate)`                | For every eligible Acquisition of `assetId`, appends a DividendAllocation; increments tradingBalance; emits `DividendReceived` event                                                                                                                                                                |
-| `recordDeposit(amount, date, source)`                              | Increments tradingBalance from external cash inflow; emits `DepositRecorded`                                                                                                                                                                                                                        |
+| `recordDeposit(amount, date, today)`                               | Appends a `Deposit` to the transaction ledger (source of truth), then increments the cached `tradingBalance`. `today` is the app-service-resolved clock value (Session 10) used to reject future-dated transactions; v1 has no `source`. Emits `DepositRecorded` |
 | `recordWithdrawal(amount, date, destination)`                      | Decrements tradingBalance; emits `WithdrawalRecorded`                                                                                                                                                                                                                                               |
 | `transferTo(targetPortfolioId, amount, date)`                      | Moves cash between portfolios under the same broker (preserves RDN total)                                                                                                                                                                                                                           |
 
@@ -194,7 +194,7 @@ Typed events (Spring Modulith `@ApplicationModuleListener` consumers):
 - `BuyRecorded(portfolioId, acquisitionId, assetId, quantity, price, fee, date)`
 - `SellRecorded(portfolioId, sellId, assetId, allocations, pricePerShare, fee, date)`
 - `DividendReceived(portfolioId, assetId, allocations, paymentDate)`
-- `DepositRecorded(portfolioId, amount, date, source)`
+- `DepositRecorded(portfolioId, amount, date)`
 - `WithdrawalRecorded(portfolioId, amount, date, destination)`
 - `TradingBalanceChanged(portfolioId, delta, newBalance)` ← consumed by Brokerage to sync RDN. The cash sync to BrokerAccount RDN is performed by application-service orchestration in one transaction per ADR-003, not by a domain event in v1. A `TradingBalanceChanged` integration event is deferred until a read-model consumer needs it or the modules are split into services.
 


### PR DESCRIPTION
## Summary
- Reconciles the domain model with what Session 11 actually built (PR #13): `Deposit` no longer carries a `source`, and `recordDeposit` appends to the transaction ledger before updating the cached trading balance
- Documentation consistency only; no code change

## What changed
- `docs/domain/domain-model.md`:
  - §4.2 `Deposit` row: removed `source` — v1 deposits always originate from RDN, so it carried no information; note added to reintroduce it only if a non-RDN cash source appears
  - §4.4 `recordDeposit` row: signature `(amount, date, source)` → `(amount, date, today)`; `today` is the app-service-resolved clock value (Session 10); clarified that it appends a `Deposit` to the ledger (source of truth) before incrementing the cached `tradingBalance`
  - §4.5 `DepositRecorded` event: dropped the `source` field for consistency

## Test plan
- [x] Docs only; no build or test impact