### PR TITLE
feat(portfolio): record buys opening an acquisition with single-rounding cost (ADR-0007)

### DIFF
--- a/docs/adr/0007-currency-scale-and-rounding-policy.md
+++ b/docs/adr/0007-currency-scale-and-rounding-policy.md
@@ -32,6 +32,22 @@ Money fee = Money.of(rawFee)                              // routes through comp
 ```
 *Compare: had the price been 9851, rawFee = 1477.65 -> rounds to 1478 (HALF_EVEN, no exact-half case). Had it been an exact-half case like 1478.5, HALF_EVEN picks 1478; HALF_UP would have picked 1479.*
 
+Worked Example 2 — compose-then-normalize (round ONCE, at the boundary):
+
+Computing a buy cost for `quantity = 1.5`, `price = 5801`, `fee = 11` (already a scale-0 `Money`):
+
+```java
+// WRONG — each Money-returning op is a rounding checkpoint, so this rounds TWICE:
+quantity.multiply(price)  // 8701.5 -> Money rounds to 8702
+        .add(fee)         // 8702 + 11 = 8713   ← off by one
+
+// RIGHT — one BigDecimal expression, normalized to Money exactly once:
+BigDecimal raw = quantity.value().multiply(price.amount()).add(fee.amount()); // 8712.5
+Money cost = Money.of(raw, price.currency());   // HALF_EVEN -> 8712
+```
+
+The rule: **a monetary intermediate is math, not money.** Because every `Money` construction is a normalization checkpoint (see the Decision above), chaining two `Money`-returning operations to build one settled amount rounds twice and can drift by ±1 IDR. Keep the whole calculation in `BigDecimal` and cross into `Money` only at the boundary where the value becomes committed aggregate state. This is why `recordBuy` computes its cost delta inline in `BigDecimal` rather than via a `Money.multiply` helper (that helper was designed and then dropped in Session 12 for exactly this reason).
+
 ## Amendment — 2026-06-08: JavaMoney/JSR-354 considered and rejected; record confirmed
 
 Implementing `Money` prompted an evaluation of JavaMoney (JSR-354, reference impl Moneta) and Joda-Money as alternatives to the hand-rolled `BigDecimal`-backed value object.

--- a/docs/domain/domain-model.md
+++ b/docs/domain/domain-model.md
@@ -124,11 +124,11 @@ sealed interface Transaction
 
 | Subtype | Attributes                                                                                                        |
 |---|-------------------------------------------------------------------------------------------------------------------|
-| `Buy` | id, portfolioId, assetId, date, quantity, price, fee, acquisitionId (the Acquisition it opened)                   |
-| `Sell` | id, portfolioId, assetId, date, price, totalQuantity, totalFee, allocations: List\<SellAllocation\>                      |
-| `Dividend` | id, portfolioId, assetId, cumDate, paymentDate, dps (dividend per share), allocations: List\<DividendAllocation\> |
-| `Deposit` | id, portfolioId, amount, date  (v1: `source` dropped — deposits always originate from RDN, so it carried no information; reintroduce if a non-RDN cash source appears) |
-| `Withdrawal` | id, portfolioId, amount, date, destination                                                                        |
+| `Buy` | id, portfolioId, date, assetId, quantity, price, fee, acquisitionId (the Acquisition it opened)                   |
+| `Sell` | id, portfolioId, date, assetId, price, totalQuantity, totalFee, allocations: List\<SellAllocation\>                      |
+| `Dividend` | id, portfolioId, date, assetId, cumDate, paymentDate, dps (dividend per share), allocations: List\<DividendAllocation\> |
+| `Deposit` | id, portfolioId, date, amount (v1: `source` dropped — deposits always originate from RDN, so it carried no information; reintroduce if a non-RDN cash source appears) |
+| `Withdrawal` | id, portfolioId, date, amount, destination                                                                        |
 
 All Transactions are immutable once recorded. Corrections are made by recording a reversing transaction, never by editing.
 
@@ -180,7 +180,7 @@ All in business language. Each enforces its invariants internally before changin
 
 | Method                                                             | Purpose                                                                                                                                                                                                                                                                                             |
 |--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `recordBuy(assetId, quantity, price, fee, date)`                   | Opens a new Acquisition; updates Holding cache; decrements tradingBalance; **returns the cash delta moved (`quantity × price + fee` as `Money`)** so the orchestrating app service applies that exact value to RDN (single source of truth — no recomputation, no drift); emits `BuyRecorded` event |
+| `recordBuy(assetId, quantity, price, fee, date, today)`                   | Opens a new Acquisition; appends `Buy` to the ledger; decrements tradingBalance; **returns the cash delta moved as a *signed* `Money`, `−(quantity × price + fee)`** so the orchestrating app service applies that exact value to RDN via one `applyCashFlow` (single source of truth — no recomputation, no sign decision, no drift). Cost is computed as a single `BigDecimal` expression normalized to `Money` once (ADR-007 line 21 — no intermediate rounding). `today` is the app-service-resolved clock value (Session 10) used to reject future-dated buys. `BuyRecorded` event + `Holding` cache deferred until `Sell` lands. |
 | `recordSell(assetId, quantity, pricePerShare, fee, date, strategy)` | Resolves allocations via strategy; validates against open Acquisitions; updates referenced Acquisitions (derived state changes); updates Holding cache; increments tradingBalance; emits `SellRecorded` event                                                                                       |
 | `recordDividend(assetId, dps, cumDate, paymentDate)`                | For every eligible Acquisition of `assetId`, appends a DividendAllocation; increments tradingBalance; emits `DividendReceived` event                                                                                                                                                                |
 | `recordDeposit(amount, date, today)`                               | Appends a `Deposit` to the transaction ledger (source of truth), then increments the cached `tradingBalance`. `today` is the app-service-resolved clock value (Session 10) used to reject future-dated transactions; v1 has no `source`. Emits `DepositRecorded` |

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/InsufficientBalanceException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/InsufficientBalanceException.java
@@ -1,0 +1,12 @@
+package com.budiyanto.fintrackr.portfolio.domain.exception;
+
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+
+public class InsufficientBalanceException extends DomainException {
+
+    public InsufficientBalanceException(Money tradingBalance, Money cost) {
+        super("Insufficient balance is not allowed. Balance: " + tradingBalance.amount() + " Cost: " + cost.amount());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/NegativeFeeException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/NegativeFeeException.java
@@ -1,0 +1,12 @@
+package com.budiyanto.fintrackr.portfolio.domain.exception;
+
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+
+public class NegativeFeeException extends DomainException {
+
+    public NegativeFeeException(Money amount) {
+        super("Negative fee is not allowed: " + amount.amount());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/NonPositivePriceException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/NonPositivePriceException.java
@@ -1,0 +1,12 @@
+package com.budiyanto.fintrackr.portfolio.domain.exception;
+
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+
+public class NonPositivePriceException extends DomainException {
+
+    public NonPositivePriceException(Money amount) {
+        super("Non positive price is not allowed: " + amount.amount());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/ZeroQuantityException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/ZeroQuantityException.java
@@ -1,0 +1,11 @@
+package com.budiyanto.fintrackr.portfolio.domain.exception;
+
+import com.budiyanto.fintrackr.portfolio.domain.model.Quantity;
+import com.budiyanto.fintrackr.shared.DomainException;
+
+public class ZeroQuantityException extends DomainException {
+
+    public ZeroQuantityException(Quantity quantity) {
+        super("Zero Quantity is not allowed: " + quantity.value());
+    }
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Acquisition.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Acquisition.java
@@ -1,0 +1,58 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import com.budiyanto.fintrackr.shared.AssetId;
+import com.budiyanto.fintrackr.shared.Money;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public class Acquisition {
+
+    private final AcquisitionId id;
+    private final PortfolioId portfolioId;
+    private final AssetId assetId;
+    private final LocalDate openDate;
+    private final Money openPrice;
+    private final Money openFee;
+    private final Quantity initialQuantity;
+
+    private Acquisition(AcquisitionId id, PortfolioId portfolioId, AssetId assetId, LocalDate openDate, Money openPrice, Money openFee, Quantity initialQuantity) {
+        this.id = id;
+        this.portfolioId = portfolioId;
+        this.assetId = assetId;
+        this.openDate = openDate;
+        this.openPrice = openPrice;
+        this.openFee = openFee;
+        this.initialQuantity = initialQuantity;
+    }
+
+    public static Acquisition create(PortfolioId portfolioId, AssetId assetId, LocalDate openDate, Money openPrice, Money openFee, Quantity initialQuantity) {
+        return new Acquisition(AcquisitionId.generate(), portfolioId, assetId, openDate, openPrice, openFee, initialQuantity);
+    }
+
+    public AcquisitionId id() { return id; }
+
+    public PortfolioId portfolioId() { return portfolioId; }
+
+    public AssetId assetId() { return assetId; }
+
+    public LocalDate openDate() { return openDate; }
+
+    public Money openPrice() { return openPrice; }
+
+    public Money openFee() { return openFee; }
+
+    public Quantity initialQuantity() { return initialQuantity; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Acquisition that = (Acquisition) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/AcquisitionId.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/AcquisitionId.java
@@ -1,0 +1,16 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record AcquisitionId(UUID value) {
+
+    public AcquisitionId {
+        Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    public static AcquisitionId generate() {
+        return new AcquisitionId(UUID.randomUUID());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Buy.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Buy.java
@@ -1,0 +1,26 @@
+package com.budiyanto.fintrackr.portfolio.domain.model;
+
+import com.budiyanto.fintrackr.shared.AssetId;
+import com.budiyanto.fintrackr.shared.Money;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public record Buy(TransactionId id, PortfolioId portfolioId, LocalDate date, AssetId assetId, Quantity quantity, Money price, Money fee, AcquisitionId acquisitionId) implements Transaction{
+
+    public Buy {
+        Objects.requireNonNull(id, "id cannot be null");
+        Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        Objects.requireNonNull(assetId, "assetId cannot be null");
+        Objects.requireNonNull(quantity, "quantity cannot be null");
+        Objects.requireNonNull(price, "price cannot be null");
+        Objects.requireNonNull(fee, "fee cannot be null");
+        Objects.requireNonNull(date, "date cannot be null");
+        Objects.requireNonNull(acquisitionId, "acquisitionId cannot be null");
+    }
+
+    public static Buy create(TransactionId id, PortfolioId portfolioId, LocalDate date, AssetId assetId, Quantity quantity, Money price, Money fee, AcquisitionId acquisitionId) {
+        return new Buy(id, portfolioId, date, assetId, quantity, price, fee, acquisitionId);
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
@@ -1,7 +1,7 @@
 package com.budiyanto.fintrackr.portfolio.domain.model;
 
-import com.budiyanto.fintrackr.portfolio.domain.exception.FutureDatedTransactionException;
-import com.budiyanto.fintrackr.portfolio.domain.exception.NonPositiveAmountException;
+import com.budiyanto.fintrackr.portfolio.domain.exception.*;
+import com.budiyanto.fintrackr.shared.AssetId;
 import com.budiyanto.fintrackr.shared.BrokerAccountId;
 import com.budiyanto.fintrackr.shared.Money;
 
@@ -17,6 +17,7 @@ public class Portfolio {
     private String name;
     private Money tradingBalance;
     private final List<Transaction> transactions;
+    private final List<Acquisition> acquisitions;
 
     private Portfolio (BrokerAccountId brokerAccountId, String name) {
         this.id = PortfolioId.generate();
@@ -24,6 +25,7 @@ public class Portfolio {
         this.name = name;
         this.tradingBalance = Money.zero();
         this.transactions = new ArrayList<>();
+        this.acquisitions = new ArrayList<>();
     }
 
     public static Portfolio create(BrokerAccountId brokerAccountId, String name) {
@@ -49,9 +51,64 @@ public class Portfolio {
         tradingBalance = tradingBalance.add(amount);
     }
 
+    public Money recordBuy(AssetId assetId, Quantity quantity, Money price, Money fee, LocalDate date, LocalDate today) {
+        Objects.requireNonNull(assetId, "assetId cannot be null");
+        Objects.requireNonNull(quantity, "quantity cannot be null");
+        Objects.requireNonNull(price, "price cannot be null");
+        Objects.requireNonNull(fee, "fee cannot be null");
+        Objects.requireNonNull(date, "date cannot be null");
+        Objects.requireNonNull(today, "today cannot be null");
+
+        if (quantity.isZero()) {
+            throw new ZeroQuantityException(quantity);
+        }
+
+        if (price.isZeroOrNegative()) {
+            throw new NonPositivePriceException(price);
+        }
+
+        if (fee.isNegative()) {
+            throw new NegativeFeeException(fee);
+        }
+
+        if (date.isAfter(today)) {
+            throw new FutureDatedTransactionException(date, today);
+        }
+
+        Money costDelta = Money.of(quantity.value().multiply(price.amount()).add(fee.amount()), price.currency()).negate();
+
+        Money endBalance = tradingBalance.add(costDelta);
+        if (endBalance.isNegative()) {
+            throw new InsufficientBalanceException(tradingBalance, costDelta.negate());
+        }
+
+        Acquisition acquisition = Acquisition.create(id, assetId, date, price, fee, quantity);
+        acquisitions.add(acquisition);
+
+        Transaction buy = Buy.create(TransactionId.generate(), id, date, assetId, quantity, price, fee, acquisition.id());
+        transactions.add(buy);
+
+        tradingBalance = endBalance;
+        return costDelta;
+    }
+
     public PortfolioId id() { return id; }
 
     public Money tradingBalance() { return tradingBalance; }
 
     public List<Transaction> transactions() { return List.copyOf(transactions); }
+
+    public List<Acquisition> acquisitions() { return List.copyOf(acquisitions); }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Portfolio portfolio = (Portfolio) o;
+        return Objects.equals(id, portfolio.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Quantity.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Quantity.java
@@ -32,6 +32,10 @@ public class Quantity {
         return new Quantity(value.setScale(4, RoundingMode.UNNECESSARY));
     }
 
+    public boolean isZero() {
+        return value.compareTo(BigDecimal.ZERO) == 0;
+    }
+
     public BigDecimal value() { return value; }
 
     // Strip tailing zeros to normalize (e.g., 10.00 -> 10)

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Transaction.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Transaction.java
@@ -2,7 +2,7 @@ package com.budiyanto.fintrackr.portfolio.domain.model;
 
 import java.time.LocalDate;
 
-public sealed interface Transaction permits Deposit {
+public sealed interface Transaction permits Deposit, Buy {
     TransactionId id();
     PortfolioId portfolioId();
     LocalDate date();

--- a/src/main/java/com/budiyanto/fintrackr/shared/BrokerAccountId.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/BrokerAccountId.java
@@ -1,7 +1,5 @@
 package com.budiyanto.fintrackr.shared;
 
-import org.springframework.validation.ObjectError;
-
 import java.util.Objects;
 import java.util.UUID;
 

--- a/src/main/java/com/budiyanto/fintrackr/shared/Money.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/Money.java
@@ -18,6 +18,10 @@ public record Money(BigDecimal amount, Currency currency) implements Comparable<
         return new Money(amount, Currency.getInstance("IDR"));
     }
 
+    public static Money of(BigDecimal amount, Currency currency) {
+        return new Money(amount, currency);
+    }
+
     public static Money zero() {
         return new Money(BigDecimal.ZERO, Currency.getInstance("IDR"));
     }
@@ -25,6 +29,10 @@ public record Money(BigDecimal amount, Currency currency) implements Comparable<
     public Money add(Money toAdd) {
         checkSameCurrency(toAdd);
         return new Money(amount.add(toAdd.amount), currency);
+    }
+
+    public Money negate() {
+        return new Money(amount.negate(), currency);
     }
 
     @Override

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioTest.java
@@ -1,25 +1,22 @@
 package com.budiyanto.fintrackr.portfolio.domain.model;
 
-import com.budiyanto.fintrackr.portfolio.domain.exception.FutureDatedTransactionException;
-import com.budiyanto.fintrackr.portfolio.domain.exception.NonPositiveAmountException;
+import com.budiyanto.fintrackr.portfolio.domain.exception.*;
+import com.budiyanto.fintrackr.shared.AssetId;
 import com.budiyanto.fintrackr.shared.BrokerAccountId;
 import com.budiyanto.fintrackr.shared.DomainException;
 import com.budiyanto.fintrackr.shared.Money;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.shaded.org.bouncycastle.asn1.isismtt.x509.MonetaryLimit;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("Portfolio Tests")
 class PortfolioTest {
@@ -37,7 +34,7 @@ class PortfolioTest {
 
     @Nested
     @DisplayName("RecordDeposit Tests")
-    class RecordDeposit {
+    class RecordDepositTest {
 
         // Happy Path
         @Test
@@ -132,8 +129,9 @@ class PortfolioTest {
 
         @ParameterizedTest
         @CsvSource({
-                "-15000, 2026-06-01",
-                "20000, 2026-12-15"
+                "0, 2026-06-01", // Zero amount
+                "-15000, 2026-06-01", // Negative amount
+                "20000, 2026-12-15" // Future date
         })
         @DisplayName("Keep balance unchanged when deposit is rejected")
         void should_leaveBalanceUnchanged_when_depositRejected(String amount, LocalDate depositDate) {
@@ -152,7 +150,238 @@ class PortfolioTest {
             // Then
             assertThat(portfolio.tradingBalance()).isEqualTo(balanceBefore);
         }
+    }
 
+    @Nested
+    @DisplayName("RecordBuy Tests")
+    class RecordBuyTest {
+
+        private final AssetId assetId = AssetId.of("ID1000109507"); // BBCA
+        private final Quantity quantity = Quantity.ofShares(new BigDecimal("1000"));
+        private final Money price = Money.of(new BigDecimal("5800"));
+        private final Money fee = Money.of(new BigDecimal("2500"));
+
+        @BeforeEach
+        void setup() {
+            // Arrange: Ensure the portfolio has sufficient balance for most buy operations.
+            // Tests with specific balance requirements will override this by making their own deposits.
+            portfolio.recordDeposit(Money.of(new BigDecimal("20000000")), date, today);
+        }
+
+        @Test
+        @DisplayName("Return the total cost as a negative delta when a buy is recorded")
+        void should_returnCostDelta_when_recordBuy() {
+            // When
+            Money costDelta = portfolio.recordBuy(assetId, quantity, price, fee, date, today);
+
+            // Then
+            assertThat(costDelta).isEqualTo(Money.of(new BigDecimal("-5802500"))); // (5800 x 1000) + 2500 = 5802500
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1.5, 5801, 0, -8702",
+                "1.6, 5801, 100, -9382",
+                "1.3, 5801, 100, -7641"
+        })
+        @DisplayName("Return the total cost as a negative delta with correct rounding when a buy is recorded")
+        void should_returnCorrectRounding_when_recordBuy(String inputQuantity, String inputPrice, String inputFee, String inputCostDelta) {
+            // Given
+            Quantity quantity = Quantity.ofUnits(new BigDecimal(inputQuantity));
+            Money price = Money.of(new BigDecimal(inputPrice));
+            Money fee = Money.of(new BigDecimal(inputFee));
+
+            // When
+            Money costDelta = portfolio.recordBuy(assetId, quantity, price, fee, date, today);
+
+            // Then
+            assertThat(costDelta).isEqualTo(Money.of(new BigDecimal(inputCostDelta)));
+        }
+
+        @Test
+        @DisplayName("Decrease the trading balance by the total cost when a buy is recorded")
+        void should_decreaseBalanceByCost_when_recordBuy() {
+            // When
+            portfolio.recordBuy(assetId, quantity, price, fee, date, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(Money.of(new BigDecimal("14197500"))); // 20000000 - 5802500 = 14197500
+        }
+
+        @Test
+        @DisplayName("Create a new open acquisition when a buy is recorded")
+        void should_createAcquisition_when_recordBuy() {
+            // When
+            portfolio.recordBuy(assetId, quantity, price, fee, date, today);
+
+            // Then
+            var acquisitions = portfolio.acquisitions();
+            assertThat(acquisitions).hasSize(1);
+
+            var acquisition = acquisitions.getFirst();
+            assertThat(acquisition.id()).isNotNull();
+            assertThat(acquisition.portfolioId()).isEqualTo(portfolio.id());
+            assertThat(acquisition.assetId()).isEqualTo(assetId);
+            assertThat(acquisition.openDate()).isEqualTo(date);
+            assertThat(acquisition.openPrice()).isEqualTo(price);
+            assertThat(acquisition.openFee()).isEqualTo(fee);
+            assertThat(acquisition.initialQuantity()).isEqualTo(quantity);
+        }
+
+        @Test
+        @DisplayName("Create a second, distinct acquisition when buying the same asset again")
+        void should_createSecondAcquisition_when_recordSecondBuyWithSameSymbol() {
+            // When
+            portfolio.recordBuy(assetId, quantity, price, fee, date, today);
+            portfolio.recordBuy(assetId, quantity, price, fee, date, today);
+
+            // Then
+            var acquisitions = portfolio.acquisitions();
+            var firstAcquisition = acquisitions.getFirst();
+            var secondAcquisition = acquisitions.get(1);
+            assertThat(acquisitions).hasSize(2);
+            assertThat(secondAcquisition.id()).isNotNull();
+            assertThat(secondAcquisition.id()).isNotEqualTo(firstAcquisition.id());
+            assertThat(portfolio.tradingBalance().amount()).isEqualTo(new BigDecimal("8395000")); // 20000000 - 5802500 - 5802500 =
+        }
+
+        @Test
+        @DisplayName("Record a Buy transaction in the ledger when a buy is recorded")
+        void should_createBuyTransactionAndRecordItInLedger_when_recordBuy() {
+            // When
+            portfolio.recordBuy(assetId, quantity, price, fee, date, today);
+
+            // Then
+            List<Transaction> transactions = portfolio.transactions();
+            Acquisition acquisition = portfolio.acquisitions().getFirst();
+            assertThat(transactions.size()).isEqualTo(2); // 1 Deposit transaction + 1 Buy transaction
+            assertThat(transactions.get(1))
+                    .isInstanceOfSatisfying(Buy.class, b -> {
+                        assertThat(b.id()).isNotNull();
+                        assertThat(b.portfolioId()).isEqualTo(portfolio.id());
+                        assertThat(b.date()).isEqualTo(date);
+                        assertThat(b.assetId()).isEqualTo(assetId);
+                        assertThat(b.quantity()).isEqualTo(quantity);
+                        assertThat(b.price()).isEqualTo(price);
+                        assertThat(b.fee()).isEqualTo(fee);
+                        assertThat(b.acquisitionId()).isEqualTo(acquisition.id());
+                    });
+        }
+
+        // Boundaries (Edge Cases)
+        @Test
+        @DisplayName("Allow a buy when the total cost exactly equals the trading balance")
+        void should_allowBuy_when_costEqualsBalance() {
+            // Given
+            portfolio = Portfolio.create(BrokerAccountId.generate(), "Exact Balance Test");
+            portfolio.recordDeposit(Money.of(new BigDecimal("5802500")), date, today);
+
+            // When
+            portfolio.recordBuy(assetId, quantity, price, fee, date, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(Money.zero());
+        }
+
+        @Test
+        @DisplayName("Allow a buy when the transaction fee is zero")
+        void should_allowBuy_when_feeIsZero() {
+            // When
+            portfolio.recordBuy(assetId, quantity, price, Money.zero(), date, today);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(Money.of(new BigDecimal("14200000"))); // 20000000 - (5800 x 1000 + 0) = 14200000
+        }
+
+        // Invariant Violations
+        @Test
+        @DisplayName("Reject a buy when the quantity is zero")
+        void should_throwException_when_quantityEqualZero() {
+            // Given
+            Quantity zeroQuantity = Quantity.ofShares(new BigDecimal("0"));
+
+            // When & Then
+            assertThatThrownBy(() -> portfolio.recordBuy(assetId, zeroQuantity, price, fee, date, today))
+                    .isInstanceOf(ZeroQuantityException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"0", "-10000"})
+        @DisplayName("Reject a buy when the price is zero or negative")
+        void should_throwException_when_priceLessThanOrEqualZero(String input) {
+            // Given
+            Money invalidPrice = Money.of(new BigDecimal(input));
+
+            // When & Then
+            assertThatThrownBy(() -> portfolio.recordBuy(assetId, quantity, invalidPrice, fee, date, today))
+                    .isInstanceOf(NonPositivePriceException.class);
+        }
+
+        @Test
+        @DisplayName("Reject a buy when the fee is negative")
+        void should_throwException_when_feeLessThanZero() {
+            // Given
+            Money negativeFee = Money.of(new BigDecimal("-1000"));
+
+            // When & Then
+            assertThatThrownBy(() -> portfolio.recordBuy(assetId, quantity, price, negativeFee, date, today))
+                    .isInstanceOf(NegativeFeeException.class);
+        }
+
+        @Test
+        @DisplayName("Reject a buy when the date is in the future")
+        void should_throwException_when_dateInFuture() {
+            // Given
+            LocalDate futureDate = LocalDate.of(2026, 12, 15);
+
+            // When & Then
+            assertThatThrownBy(() -> portfolio.recordBuy(assetId, quantity, price, fee, futureDate, today))
+                    .isInstanceOf(FutureDatedTransactionException.class);
+        }
+
+        @Test
+        @DisplayName("Reject a buy when the total cost exceeds the trading balance")
+        void should_throwException_when_costGreaterThanBalance() {
+            // Given
+            portfolio = Portfolio.create(BrokerAccountId.generate(), "Insufficient Balance Test");
+            portfolio.recordDeposit(Money.of(new BigDecimal(4000000)), date, today);
+
+            // When & Then
+            assertThatThrownBy(() ->portfolio.recordBuy(assetId, quantity, price, fee, date, today))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "0, 10000, 1500, 2026-06-10", // Zero quantity
+                "100, 0, 1500, 2026-06-10", // Zero price
+                "100, -1000, 1500, 2026-06-10", // Negative price
+                "100, 10000, -1500, 2026-06-10", // Negative fee
+                "100, 10000, 1500, 2026-12-20", // Future date
+                "100, 10000, 1500, 2026-06-10", // cost > balance
+        })
+        @DisplayName("Keep portfolio state unchanged when a buy is rejected")
+        void should_leaveStateUnchanged_when_buyRejected(String inputQuantity, String inputPrice, String inputFee, String inputDate) {
+            // Given
+            Quantity quantity = Quantity.ofShares(new BigDecimal(inputQuantity));
+            Money price = Money.of(new BigDecimal(inputPrice));
+            Money fee = Money.of(new BigDecimal(inputFee));
+            LocalDate buyingDate = LocalDate.parse(inputDate);
+
+            portfolio = Portfolio.create(BrokerAccountId.generate(), "State Unchanged Test");
+            portfolio.recordDeposit(Money.of(new BigDecimal("10000")), LocalDate.of(2026, 6, 1), today);
+
+            Money balanceBefore = portfolio.tradingBalance();
+
+            // When
+            assertThatThrownBy(() -> portfolio.recordBuy(assetId, quantity, price, fee, buyingDate, today))
+                    .isInstanceOf(DomainException.class);
+
+            // Then
+            assertThat(portfolio.tradingBalance()).isEqualTo(balanceBefore);
+            assertThat(portfolio.transactions().size()).isEqualTo(1); // Should contain only initial deposit transaction
+            assertThat(portfolio.acquisitions().size()).isEqualTo(0); // Should contain no acquisitions
+        }
 
     }
 


### PR DESCRIPTION
## What
Implements `Portfolio.recordBuy`: opens an immutable `Acquisition`, appends a `Buy` to the transaction ledger, decrements `tradingBalance`, and returns the cash movement as a **signed** `Money` delta.

## Why signed delta
`recordBuy` returns `-(quantity × price + fee)`. The orchestrating app service (coming in a follow-up) applies it to RDN via a single `applyCashFlow(delta)`, correct by sign for every transaction type. No per-type debit/credit method, no sign decision at the call site. Same delta hits both the portfolio balance and RDN, so `sum(portfolios) == rdn` is preserved by construction (ADR-003).

## Rounding fix
The cost is one `BigDecimal` expression normalized to `Money` once, per ADR-007 line 21. The earlier `quantity.multiply(price).add(fee)` rounded twice (each `Money` is a rounding checkpoint) and drifted by 1 IDR on fractional quantities (1.5 × 5801 + 11 gave 8713 instead of 8712). `Quantity.multiply`/`Money.multiply` removed; ADR-007 gains a compose-then-normalize worked example.

## Invariants (all guard before any mutation, all-or-nothing)
quantity > 0, price > 0, fee >= 0, date <= today, cost <= tradingBalance. New exceptions: ZeroQuantity, NonPositivePrice, NegativeFee, InsufficientBalance.

## Deferred (until Sell lands)
`remainingQuantity`, `AcquisitionStatus`, the `Holding` cache, and the `BuyRecorded` event. Nothing can change them in a buy-only world (YAGNI).

## Tests
`PortfolioTest` gains a 22-test `RecordBuy` suite (happy path, boundaries, every invariant, state-unchanged-on-rejection). Full suite: 32 green.