### PR TITLE
feat(brokerage): add BrokerAccount aggregate with fee and cash-flow API

### DIFF
--- a/docs/domain/domain-model.md
+++ b/docs/domain/domain-model.md
@@ -65,10 +65,7 @@ Three contexts, each with a clear responsibility.
 │                        │ cash   │   Trading Balance               │
 └────────────────────────┘        └─────────────────────────────────┘
 
-Dependency direction: Portfolio Management → Brokerage, through Brokerage's
-published API. PM's RecordBuyUseCase calls computeBuyFee + applyCashFlow in
-one transaction (ADR-003, amended Session 004). Brokerage does NOT depend on
-Portfolio Management.
+Dependency direction: Portfolio Management → Brokerage, through Brokerage's published API. PM's RecordBuyUseCase calls computeBuyFee + applyCashFlow in one transaction (ADR-003, as amended). Brokerage does NOT depend on Portfolio Management.
 ```
 
 - **Portfolio Management** — the heart of the system. Owns Acquisitions, Sells, Dividends, Holdings, Trading Balance. Where most of the business logic lives.
@@ -180,10 +177,10 @@ All in business language. Each enforces its invariants internally before changin
 
 | Method                                                             | Purpose                                                                                                                                                                                                                                                                                             |
 |--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `recordBuy(assetId, quantity, price, fee, date, today)`                   | Opens a new Acquisition; appends `Buy` to the ledger; decrements tradingBalance; **returns the cash delta moved as a *signed* `Money`, `−(quantity × price + fee)`** so the orchestrating app service applies that exact value to RDN via one `applyCashFlow` (single source of truth — no recomputation, no sign decision, no drift). Cost is computed as a single `BigDecimal` expression normalized to `Money` once (ADR-007 line 21 — no intermediate rounding). `today` is the app-service-resolved clock value (Session 10) used to reject future-dated buys. `BuyRecorded` event + `Holding` cache deferred until `Sell` lands. |
+| `recordBuy(assetId, quantity, price, fee, date, today)`                   | Opens a new Acquisition; appends `Buy` to the ledger; decrements tradingBalance; **returns the cash delta moved as a *signed* `Money`, `−(quantity × price + fee)`** so the orchestrating app service applies that exact value to RDN via one `applyCashFlow` (single source of truth — no recomputation, no sign decision, no drift). Cost is computed as a single `BigDecimal` expression normalized to `Money` once (ADR-007 line 21 — no intermediate rounding). `today` is the app-service-resolved clock value used to reject future-dated buys (the aggregate stays clock-free for deterministic tests). `BuyRecorded` event + `Holding` cache deferred until `Sell` lands. |
 | `recordSell(assetId, quantity, pricePerShare, fee, date, strategy)` | Resolves allocations via strategy; validates against open Acquisitions; updates referenced Acquisitions (derived state changes); updates Holding cache; increments tradingBalance; emits `SellRecorded` event                                                                                       |
 | `recordDividend(assetId, dps, cumDate, paymentDate)`                | For every eligible Acquisition of `assetId`, appends a DividendAllocation; increments tradingBalance; emits `DividendReceived` event                                                                                                                                                                |
-| `recordDeposit(amount, date, today)`                               | Appends a `Deposit` to the transaction ledger (source of truth), then increments the cached `tradingBalance`. `today` is the app-service-resolved clock value (Session 10) used to reject future-dated transactions; v1 has no `source`. Emits `DepositRecorded` |
+| `recordDeposit(amount, date, today)`                               | Appends a `Deposit` to the transaction ledger (source of truth), then increments the cached `tradingBalance`. `today` is the app-service-resolved clock value used to reject future-dated transactions; v1 has no `source`. Emits `DepositRecorded` |
 | `recordWithdrawal(amount, date, destination)`                      | Decrements tradingBalance; emits `WithdrawalRecorded`                                                                                                                                                                                                                                               |
 | `transferTo(targetPortfolioId, amount, date)`                      | Moves cash between portfolios under the same broker (preserves RDN total)                                                                                                                                                                                                                           |
 
@@ -209,9 +206,10 @@ BrokerAccount (aggregate root, entity)
 ├─ id
 ├─ name (e.g., "Stockbit")
 ├─ rdn: Money                ← regulated cash balance
-├─ feeStructure: FeeStructure
-└─ portfolioIds: Set<PortfolioId>
+└─ feeStructure: FeeStructure
 ```
+
+Brokerage holds no portfolio references. The association is unidirectional: each Portfolio holds a `brokerAccountId` (shared kernel). A `Set<PortfolioId>` here would require Brokerage to import from Portfolio Management, inverting the ADR-003 dependency direction (and failing `ApplicationModules.verify()`). Enumerating a broker's portfolios is a query on the PM side (repository lookup by `brokerAccountId`), not aggregate state — `BrokerAccount`'s own invariants (`rdn ≥ 0`, fee rates in `[0,1]`) need no portfolio knowledge.
 
 ### 5.2 Value Objects
 
@@ -225,10 +223,10 @@ FeeStructure (value object)
 
 | Method | Purpose |
 |---|---|
-| `depositToBroker(amount, date)` | External cash inflow → increases RDN. User then allocates to a Portfolio via `Portfolio.recordDeposit`. |
-| `withdrawFromBroker(amount, date)` | External cash outflow → decreases RDN. Originates from a Portfolio's `recordWithdrawal`. |
 | `updateFeeStructure(newStructure)` | Changes fee rates. Affects only future transactions; historical fees are preserved as recorded (no FeeStructureHistory needed). |
-| `applyCashFlow(delta, date)` | Applies a cash delta to RDN. Invoked by Portfolio Management's use-case application service (e.g., `RecordBuyUseCase`) through Brokerage's published API, within the same database transaction (per ADR-003, amended Session 004). Not event-driven in v1. |
+| `applyCashFlow(delta)` | Applies a signed cash delta to RDN; rejects a delta that would drive RDN below zero (result must stay ≥ 0 — reaching exactly zero is legal). Invoked by Portfolio Management's use-case application service (e.g., `RecordBuyUseCase`) through Brokerage's published API, within the same database transaction (per ADR-003, as amended). Not event-driven in v1. No `date` parameter: every v1 cash flow originates from a PM transaction whose date is already validated and recorded in the PM ledger (ADR-004 — single source of truth); `BrokerAccount` keeps no ledger, so a date here would have no consumer. Reintroduce if a cash flow ever originates outside a Portfolio (unallocated broker deposit, account fees, RDN interest). |
+
+V1 has no broker-level cash entry points (no `depositToBroker`/`withdrawFromBroker`). All cash movements enter through `Portfolio` methods (`recordDeposit`, `recordWithdrawal`, `recordBuy`, …) and reach the RDN via `applyCashFlow` inside the orchestrating application service's single transaction (ADR-003) — five transaction types, one cash-sync code path, one invariant check. Broker-level deposit/withdrawal returns if a cash flow ever exists outside a portfolio (post-v1 default-portfolio item in `backlog.md` — the same trigger that would reintroduce `date` on `applyCashFlow`).
 
 ### 5.4 Fee handling policy
 

--- a/src/main/java/com/budiyanto/fintrackr/brokerage/domain/exception/InsufficientRdnException.java
+++ b/src/main/java/com/budiyanto/fintrackr/brokerage/domain/exception/InsufficientRdnException.java
@@ -1,0 +1,12 @@
+package com.budiyanto.fintrackr.brokerage.domain.exception;
+
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+
+public class InsufficientRdnException extends DomainException {
+
+    public InsufficientRdnException(Money rdn, Money delta) {
+        super("Apply cash flow rejected: would drive RDN below zero. RDN: " + rdn.amount() + ", Delta: " + delta.amount());
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/BrokerAccount.java
+++ b/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/BrokerAccount.java
@@ -3,6 +3,7 @@ package com.budiyanto.fintrackr.brokerage.domain.model;
 import com.budiyanto.fintrackr.brokerage.domain.exception.InsufficientRdnException;
 import com.budiyanto.fintrackr.shared.BrokerAccountId;
 import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.Quantity;
 
 import java.util.Objects;
 
@@ -39,6 +40,14 @@ public class BrokerAccount {
             throw new InsufficientRdnException(rdn, delta);
         }
         rdn = result;
+    }
+
+    public Money computeBuyFee(Quantity quantity, Money price) {
+        return feeStructure.computeBuyFee(quantity, price);
+    }
+
+    public Money computeSellFee(Quantity quantity, Money price) {
+        return feeStructure.computeSellFee(quantity, price);
     }
 
     private void validateName(String name) {

--- a/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/BrokerAccount.java
+++ b/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/BrokerAccount.java
@@ -1,0 +1,71 @@
+package com.budiyanto.fintrackr.brokerage.domain.model;
+
+import com.budiyanto.fintrackr.brokerage.domain.exception.InsufficientRdnException;
+import com.budiyanto.fintrackr.shared.BrokerAccountId;
+import com.budiyanto.fintrackr.shared.Money;
+
+import java.util.Objects;
+
+public class BrokerAccount {
+
+    private final BrokerAccountId id;
+    private String name;
+    private Money rdn;
+    private FeeStructure feeStructure;
+
+    private BrokerAccount(String name, FeeStructure feeStructure) {
+        validateName(name);
+        Objects.requireNonNull(feeStructure, "feeStructure cannot be null");
+
+        this.id = BrokerAccountId.generate();
+        this.name = name;
+        this.rdn = Money.zero();
+        this.feeStructure = feeStructure;
+    }
+
+    public static BrokerAccount create(String name, FeeStructure feeStructure) {
+        return new BrokerAccount(name, feeStructure);
+    }
+
+    public void rename(String name) {
+        validateName(name);
+        this.name = name;
+    }
+
+    public void applyCashFlow(Money delta) {
+        Objects.requireNonNull(delta, "delta cannot be null");
+        Money result = rdn.add(delta);
+        if (result.isNegative()) {
+            throw new InsufficientRdnException(rdn, delta);
+        }
+        rdn = result;
+    }
+
+    private void validateName(String name) {
+        Objects.requireNonNull(name, "name cannot be null");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name cannot be blank");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        BrokerAccount that = (BrokerAccount) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    public BrokerAccountId id() { return id; }
+
+    public String name() { return name; }
+
+    public Money rdn() { return rdn; }
+
+    public FeeStructure feeStructure() { return feeStructure; }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/FeeStructure.java
+++ b/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/FeeStructure.java
@@ -1,0 +1,16 @@
+package com.budiyanto.fintrackr.brokerage.domain.model;
+
+import java.util.Objects;
+
+public record FeeStructure(Percentage buyRate, Percentage sellRate) {
+
+    public FeeStructure {
+        Objects.requireNonNull(buyRate, "buyRate cannot be null");
+        Objects.requireNonNull(sellRate, "sellRate cannot be null");
+    }
+
+    public static FeeStructure of(Percentage buyRate, Percentage sellRate) {
+        return new FeeStructure(buyRate, sellRate);
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/FeeStructure.java
+++ b/src/main/java/com/budiyanto/fintrackr/brokerage/domain/model/FeeStructure.java
@@ -1,5 +1,9 @@
 package com.budiyanto.fintrackr.brokerage.domain.model;
 
+import com.budiyanto.fintrackr.shared.Quantity;
+import com.budiyanto.fintrackr.shared.Money;
+
+import java.math.BigDecimal;
 import java.util.Objects;
 
 public record FeeStructure(Percentage buyRate, Percentage sellRate) {
@@ -11,6 +15,26 @@ public record FeeStructure(Percentage buyRate, Percentage sellRate) {
 
     public static FeeStructure of(Percentage buyRate, Percentage sellRate) {
         return new FeeStructure(buyRate, sellRate);
+    }
+
+    public Money computeBuyFee(Quantity quantity, Money price) {
+        return computeFee(quantity, price, buyRate);
+    }
+
+    public Money computeSellFee(Quantity quantity, Money price) {
+        return computeFee(quantity, price, sellRate);
+    }
+
+    private Money computeFee(Quantity quantity, Money price, Percentage rate) {
+        Objects.requireNonNull(quantity, "quantity cannot be null");
+        Objects.requireNonNull(price, "price cannot be null");
+
+        if (price.isNegative()) {
+            throw new IllegalArgumentException("price cannot be negative");
+        }
+
+        BigDecimal result = quantity.value().multiply(price.amount()).multiply(rate.rate());
+        return Money.of(result, price.currency());
     }
 
 }

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/InsufficientBalanceException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/InsufficientBalanceException.java
@@ -6,7 +6,7 @@ import com.budiyanto.fintrackr.shared.Money;
 public class InsufficientBalanceException extends DomainException {
 
     public InsufficientBalanceException(Money tradingBalance, Money cost) {
-        super("Insufficient balance is not allowed. Balance: " + tradingBalance.amount() + " Cost: " + cost.amount());
+        super("Insufficient balance is not allowed. Balance: " + tradingBalance.amount() + ", Cost: " + cost.amount());
     }
 
 }

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/ZeroQuantityException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/exception/ZeroQuantityException.java
@@ -1,6 +1,6 @@
 package com.budiyanto.fintrackr.portfolio.domain.exception;
 
-import com.budiyanto.fintrackr.portfolio.domain.model.Quantity;
+import com.budiyanto.fintrackr.shared.Quantity;
 import com.budiyanto.fintrackr.shared.DomainException;
 
 public class ZeroQuantityException extends DomainException {

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Acquisition.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Acquisition.java
@@ -2,6 +2,7 @@ package com.budiyanto.fintrackr.portfolio.domain.model;
 
 import com.budiyanto.fintrackr.shared.AssetId;
 import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.Quantity;
 
 import java.time.LocalDate;
 import java.util.Objects;

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Buy.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Buy.java
@@ -2,6 +2,7 @@ package com.budiyanto.fintrackr.portfolio.domain.model;
 
 import com.budiyanto.fintrackr.shared.AssetId;
 import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.Quantity;
 
 import java.time.LocalDate;
 import java.util.Objects;

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
@@ -4,6 +4,7 @@ import com.budiyanto.fintrackr.portfolio.domain.exception.*;
 import com.budiyanto.fintrackr.shared.AssetId;
 import com.budiyanto.fintrackr.shared.BrokerAccountId;
 import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.Quantity;
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/src/main/java/com/budiyanto/fintrackr/shared/Quantity.java
+++ b/src/main/java/com/budiyanto/fintrackr/shared/Quantity.java
@@ -1,4 +1,4 @@
-package com.budiyanto.fintrackr.portfolio.domain.model;
+package com.budiyanto.fintrackr.shared;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/src/test/java/com/budiyanto/fintrackr/brokerage/domain/model/BrokerAccountTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/brokerage/domain/model/BrokerAccountTest.java
@@ -1,0 +1,226 @@
+package com.budiyanto.fintrackr.brokerage.domain.model;
+
+import com.budiyanto.fintrackr.brokerage.domain.exception.InsufficientRdnException;
+import com.budiyanto.fintrackr.shared.DomainException;
+import com.budiyanto.fintrackr.shared.Money;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("BrokerAccount Tests")
+class BrokerAccountTest {
+
+    // Given
+    private BrokerAccount brokerAccount;
+    private final String name = "Stockbit";
+    private final FeeStructure feeStructure = FeeStructure.of(
+            Percentage.of(new BigDecimal("0.0015")),
+            Percentage.of(new BigDecimal("0.0025")));
+
+    @BeforeEach
+    void setUp() {
+        brokerAccount = BrokerAccount.create(name, feeStructure);
+    }
+
+    @Nested
+    @DisplayName("Create BrokerAccount Tests")
+    class CreateTest {
+
+        @Test
+        @DisplayName("Create a BrokerAccount when inputs are valid")
+        void should_createBrokerAccount_when_inputsAreValid() {
+            // When
+            var result = BrokerAccount.create(name, feeStructure);
+
+            // Then
+            assertThat(result.id()).isNotNull();
+            assertThat(result.name()).isEqualTo(name);
+            assertThat(result.feeStructure()).isEqualTo(feeStructure);
+            assertThat(result.rdn()).isEqualTo(Money.zero());
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideNullArguments")
+        @DisplayName("Reject BrokerAccount creation when input arguments are null")
+        void should_throwNPE_when_inputsAreNull(String name, FeeStructure feeStructure) {
+            // When & Then
+            assertThatThrownBy(() -> BrokerAccount.create(name, feeStructure))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        private static Stream<Arguments> provideNullArguments() {
+            var feeStructure = FeeStructure.of(
+                    Percentage.of(new BigDecimal("0.0015")),
+                    Percentage.of(new BigDecimal("0.0025")));
+
+            return Stream.of(
+                    Arguments.of(null, feeStructure),
+                    Arguments.of("Stockbit", null));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   ", "\t", "\n"})
+        @DisplayName("Reject BrokerAccount creation when input name is empty or blank")
+        void should_throwIAE_when_nameIsBlankOrEmpty(String name) {
+            // When & Then
+            assertThatThrownBy(() -> BrokerAccount.create(name, feeStructure))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Rename Tests")
+    class RenameTest {
+
+        @Test
+        @DisplayName("Rename BrokerAccount when input name is valid")
+        void should_rename_when_inputNameIsValid() {
+            // Given
+            String newName = "New Name";
+
+            // When
+            brokerAccount.rename(newName);
+
+            // Then
+            assertThat(brokerAccount.name()).isEqualTo(newName);
+        }
+
+        @Test
+        @DisplayName("Reject rename when input name is null")
+        void should_throwNPE_when_inputNameIsNull() {
+            // When & Then
+            assertThatThrownBy(() -> brokerAccount.rename(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   ", "\t", "\n"})
+        @DisplayName("Reject rename when input name is empty or blank")
+        void should_throwIAE_when_inputNameIsEmptyOrBlank(String name) {
+            // When & Then
+            assertThatThrownBy(() -> brokerAccount.rename(name))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Apply Cash Flow Tests")
+    class ApplyCashFlowTest {
+
+        @Test
+        @DisplayName("Increase RDN when a positive delta is successfully applied")
+        void should_increaseRdn_when_deltaIsPositive() {
+            // Given
+            var currentRdn = brokerAccount.rdn();
+            var delta = Money.of(new BigDecimal("15000"));
+
+            // When
+            brokerAccount.applyCashFlow(delta);
+
+            // Then
+            assertThat(brokerAccount.rdn()).isEqualTo(currentRdn.add(delta));
+        }
+
+        @Test
+        @DisplayName("Decrease RDN when a negative delta is successfully applied")
+        void should_decreaseRdn_when_deltaIsNegative() {
+            // Given
+            var initialDeposit = Money.of(new BigDecimal("60000"));
+            brokerAccount.applyCashFlow(initialDeposit);
+            var delta = Money.of(new BigDecimal("-25000"));
+
+            // When
+            brokerAccount.applyCashFlow(delta);
+
+            // Then
+            assertThat(brokerAccount.rdn()).isEqualTo(Money.of(new BigDecimal("35000")));
+        }
+
+        @Test
+        @DisplayName("Accumulate the rdn when multiple cash flows are correctly applied")
+        void should_accumulateRdn_when_applyMultipleCashFlows() {
+            // Given
+            Money amount1 = Money.of(new BigDecimal("15000"));
+            Money amount2 = Money.of(new BigDecimal("-8000"));
+            Money amount3 = Money.of(new BigDecimal("25000"));
+
+            // When
+            brokerAccount.applyCashFlow(amount1);
+            brokerAccount.applyCashFlow(amount2);
+            brokerAccount.applyCashFlow(amount3);
+
+            // Then
+            assertThat(brokerAccount.rdn()).isEqualTo(Money.of(new BigDecimal("32000")));
+        }
+
+        @Test
+        @DisplayName("Decrease RDN to zero when delta equals negative RDN")
+        void should_allowRdnToReachZero_when_deltaEqualsNegativeRdn() {
+            // Given
+            var currentRdn = Money.of(new BigDecimal("25000"));
+            brokerAccount.applyCashFlow(currentRdn);
+            var delta = Money.of(new BigDecimal("-25000"));
+
+            // When
+            brokerAccount.applyCashFlow(delta);
+
+            // Then
+            assertThat(brokerAccount.rdn()).isEqualTo(Money.zero());
+        }
+
+        @Test
+        @DisplayName("Do nothing when delta is zero")
+        void should_doNothing_when_deltaIsZero() {
+            // Given
+            var currentRdn = brokerAccount.rdn();
+
+            // When
+            brokerAccount.applyCashFlow(Money.zero());
+
+            // Then
+            assertThat(brokerAccount.rdn()).isEqualTo(currentRdn);
+        }
+
+        @Test
+        @DisplayName("Reject applying cash flow when delta is null")
+        void should_throwNPE_when_deltaIsNull() {
+            // When & Then
+            assertThatThrownBy(() -> brokerAccount.applyCashFlow(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Reject applying cash flow when RDN is insufficient")
+        void should_throwInsufficientRdnException_when_rdnIsInsufficient() {
+            // Given
+            brokerAccount.applyCashFlow(Money.of(new BigDecimal("10000")));
+
+            // When & Then
+            assertThatThrownBy(() -> brokerAccount.applyCashFlow(Money.of(new BigDecimal("-25000"))))
+                    .isInstanceOf(InsufficientRdnException.class);
+        }
+
+        @Test
+        @DisplayName("Keep RDN unchanged when applying cash flow is rejected")
+        void should_leaveRdnUnchanged_when_applyCashFlowRejected() {
+            // Given
+            brokerAccount.applyCashFlow(Money.of(new BigDecimal("10000")));
+            var currentRdn = brokerAccount.rdn();
+
+            // When
+            assertThatThrownBy(() -> brokerAccount.applyCashFlow(Money.of(new BigDecimal("-20000"))))
+                    .isInstanceOf(InsufficientRdnException.class);
+
+            // Then
+            assertThat(brokerAccount.rdn()).isEqualTo(currentRdn);
+        }
+    }
+
+}

--- a/src/test/java/com/budiyanto/fintrackr/brokerage/domain/model/BrokerAccountTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/brokerage/domain/model/BrokerAccountTest.java
@@ -1,11 +1,16 @@
 package com.budiyanto.fintrackr.brokerage.domain.model;
 
 import com.budiyanto.fintrackr.brokerage.domain.exception.InsufficientRdnException;
-import com.budiyanto.fintrackr.shared.DomainException;
 import com.budiyanto.fintrackr.shared.Money;
-import org.junit.jupiter.api.*;
+import com.budiyanto.fintrackr.shared.Quantity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.util.stream.Stream;
@@ -222,5 +227,42 @@ class BrokerAccountTest {
             assertThat(brokerAccount.rdn()).isEqualTo(currentRdn);
         }
     }
+
+    @Nested
+    @DisplayName("BrokerAccount ComputeBuyFee Tests")
+    class ComputeBuyFeeTest {
+        @Test
+        @DisplayName("Compute the correct buy fee for valid inputs")
+        void should_computeCorrectBuyFee_when_inputsAreValid() {
+            // Given
+            Quantity quantity = Quantity.ofUnits(new BigDecimal("1000"));
+            Money price = Money.of(new BigDecimal("1500"));
+
+            // When
+            Money buyFee = brokerAccount.computeBuyFee(quantity, price);
+
+            // Then
+            assertThat(buyFee).isEqualTo(Money.of(new BigDecimal("2250")));
+        }
+    }
+
+    @Nested
+    @DisplayName("BrokerAccount ComputeSellFee Tests")
+    class ComputeSellFeeTest {
+        @Test
+        @DisplayName("Compute the correct sell fee for valid inputs")
+        void should_computeCorrectSellFee_when_inputsAreValid() {
+            // Given
+            Quantity quantity = Quantity.ofUnits(new BigDecimal("1000"));
+            Money price = Money.of(new BigDecimal("1500"));
+
+            // When
+            Money sellFee = brokerAccount.computeSellFee(quantity, price);
+
+            // Then
+            assertThat(sellFee).isEqualTo(Money.of(new BigDecimal("3750")));
+        }
+    }
+
 
 }

--- a/src/test/java/com/budiyanto/fintrackr/brokerage/domain/model/FeeStructureTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/brokerage/domain/model/FeeStructureTest.java
@@ -1,0 +1,198 @@
+package com.budiyanto.fintrackr.brokerage.domain.model;
+
+import com.budiyanto.fintrackr.shared.Quantity;
+import com.budiyanto.fintrackr.shared.Money;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("FeeStructure Tests")
+class FeeStructureTest {
+
+    // Given
+    private final Percentage buyRate = Percentage.of(new BigDecimal("0.0015"));
+    private final Percentage sellRate = Percentage.of(new BigDecimal("0.0025"));
+    private final FeeStructure feeStructure = FeeStructure.of(buyRate, sellRate);
+
+    private final Quantity quantity = Quantity.ofShares(new BigDecimal("1000"));
+    private final Money price = Money.of(new BigDecimal("150"));
+
+    @Nested
+    @DisplayName("FeeStructure ComputeBuyFee Tests")
+    class ComputeBuyFee {
+
+        @Test
+        @DisplayName("Compute the correct buy fee for valid inputs")
+        void should_computeCorrectBuyFee_when_inputsAreValid() {
+            // When
+            var buyFee = feeStructure.computeBuyFee(quantity, price);
+
+            // Then
+            assertThat(buyFee).isEqualTo(Money.of(new BigDecimal("225"))); // 1000 * 150 * 0.0015 = 225
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "3, 1250, 6",
+                "5, 1625, 12",
+                "7, 1000, 10",
+                "2, 500, 2",
+        })
+        @DisplayName("Compute the correct buy fee with rounding for fractional fee")
+        void should_computeCorrectBuyFeeWithRounding_when_rawFeeIsFractional(String quantityInput, String priceInput, String expected) {
+            // Given
+            var quantity = Quantity.ofShares(new BigDecimal(quantityInput));
+            var price = Money.of(new BigDecimal(priceInput));
+
+            // When
+            var buyFee = feeStructure.computeBuyFee(quantity, price);
+
+            // Then
+            assertThat(buyFee).isEqualTo(Money.of(new BigDecimal(expected)));
+        }
+
+        @Test
+        @DisplayName("Returns zero buy fee when quantity is zero")
+        void should_returnZeroFee_when_quantityIsZero() {
+            // Given
+            var quantity = Quantity.ofUnits(BigDecimal.ZERO);
+
+            // When
+            var buyFee = feeStructure.computeBuyFee(quantity, price);
+
+            // Then
+            assertThat(buyFee).isEqualTo(Money.zero());
+        }
+
+        @Test
+        @DisplayName("Returns zero buy fee when price is zero")
+        void should_returnZeroFee_when_priceIsZero() {
+            // Given
+            var price = Money.zero();
+
+            // When
+            var buyFee = feeStructure.computeBuyFee(quantity, price);
+
+            // Then
+            assertThat(buyFee).isEqualTo(Money.zero());
+        }
+
+        @Test
+        @DisplayName("Reject calculating buy fee when quantity is null")
+        void should_throwNPE_when_quantityIsNull() {
+            // When & Then
+            assertThatThrownBy(() -> feeStructure.computeBuyFee(null, price))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Reject calculating buy fee when price is null")
+        void should_throwNPE_when_priceIsNull() {
+            // When & Then
+            assertThatThrownBy(() -> feeStructure.computeBuyFee(quantity, null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Reject calculating buy fee when price is negative")
+        void should_throwIAE_when_priceIsNegative() {
+            // When & Then
+            assertThatThrownBy(() -> feeStructure.computeBuyFee(quantity, Money.of(new BigDecimal("-1500"))))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("FeeStructure ComputeSellFee Tests")
+    class ComputeSellFee {
+
+        @Test
+        @DisplayName("Compute the correct sell fee for valid inputs")
+        void should_computeCorrectSellFee_when_inputsAreValid() {
+            // When
+            var sellFee = feeStructure.computeSellFee(quantity, price);
+
+            // Then
+            assertThat(sellFee).isEqualTo(Money.of(new BigDecimal("375"))); // 1000 * 150 * 0.0025 = 375
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "5, 3750, 47",
+                "3, 1250, 9",
+                "6, 700, 10",
+                "2, 300, 2",
+        })
+        @DisplayName("Compute the correct sell fee with rounding for fractional fee")
+        void should_computeCorrectSellFeeWithRounding_when_rawFeeIsFractional(String quantityInput, String priceInput, String expected) {
+            // Given
+            var quantity = Quantity.ofShares(new BigDecimal(quantityInput));
+            var price = Money.of(new BigDecimal(priceInput));
+
+            // When
+            var sellFee = feeStructure.computeSellFee(quantity, price);
+
+            // Then
+            assertThat(sellFee).isEqualTo(Money.of(new BigDecimal(expected)));
+        }
+
+        @Test
+        @DisplayName("Returns zero sell fee when quantity is zero")
+        void should_returnZeroFee_when_quantityIsZero() {
+            // Given
+            var quantity = Quantity.ofUnits(BigDecimal.ZERO);
+
+            // When
+            var sellFee = feeStructure.computeSellFee(quantity, price);
+
+            // Then
+            assertThat(sellFee).isEqualTo(Money.zero());
+        }
+
+        @Test
+        @DisplayName("Returns zero sell fee when price is zero")
+        void should_returnZeroFee_when_priceIsZero() {
+            // Given
+            var price = Money.zero();
+
+            // When
+            var sellFee = feeStructure.computeSellFee(quantity, price);
+
+            // Then
+            assertThat(sellFee).isEqualTo(Money.zero());
+        }
+
+        @Test
+        @DisplayName("Reject calculating sell fee when quantity is null")
+        void should_throwNPE_when_quantityIsNull() {
+            // When & Then
+            assertThatThrownBy(() -> feeStructure.computeSellFee(null, price))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Reject calculating sell fee when price is null")
+        void should_throwNPE_when_priceIsNull() {
+            // When & Then
+            assertThatThrownBy(() -> feeStructure.computeSellFee(quantity, null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("Reject calculating sell fee when price is negative")
+        void should_throwIAE_when_priceIsNegative() {
+            // When & Then
+            assertThatThrownBy(() -> feeStructure.computeSellFee(quantity, Money.of(new BigDecimal("-1500"))))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+}

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/domain/model/PortfolioTest.java
@@ -1,16 +1,12 @@
 package com.budiyanto.fintrackr.portfolio.domain.model;
 
 import com.budiyanto.fintrackr.portfolio.domain.exception.*;
-import com.budiyanto.fintrackr.shared.AssetId;
-import com.budiyanto.fintrackr.shared.BrokerAccountId;
-import com.budiyanto.fintrackr.shared.DomainException;
-import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.*;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.shaded.org.bouncycastle.asn1.isismtt.x509.MonetaryLimit;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;

--- a/src/test/java/com/budiyanto/fintrackr/shared/QuantityTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/shared/QuantityTest.java
@@ -1,4 +1,4 @@
-package com.budiyanto.fintrackr.portfolio.domain.model;
+package com.budiyanto.fintrackr.shared;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;


### PR DESCRIPTION
## What
- `BrokerAccount` aggregate: `create` (RDN starts at zero), `rename`, `applyCashFlow(signed delta)` rejecting any result below zero
- `FeeStructure.computeBuyFee`/`computeSellFee`: single BigDecimal composition, normalized to Money once (ADR-007), HALF_EVEN pinned by tie tests both directions
- `InsufficientRdnException` extending shared `DomainException` (ADR-011)
- `Quantity` promoted to the shared kernel (second consumer: Brokerage)

## Why
Prerequisite for `RecordBuyUseCase` (ADR-003 orchestration): the app service needs `computeBuyFee` + `applyCashFlow` in one transaction with `recordBuy`.

## Design notes
- No portfolio references on `BrokerAccount` — unidirectional association, `Portfolio` owns `brokerAccountId`
- No broker-level deposit/withdraw in v1: all cash enters via Portfolio methods, one cash-sync code path
- `applyCashFlow` takes no date: every v1 cash flow is already dated and recorded in the PM ledger (single source of truth, ADR-004)