### PR TITLE
feat(portfolio): orchestrate record-buy across Portfolio and BrokerAccount

### DIFF
--- a/src/main/java/com/budiyanto/fintrackr/brokerage/BrokerageApi.java
+++ b/src/main/java/com/budiyanto/fintrackr/brokerage/BrokerageApi.java
@@ -1,0 +1,13 @@
+package com.budiyanto.fintrackr.brokerage;
+
+import com.budiyanto.fintrackr.shared.BrokerAccountId;
+import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.Quantity;
+
+public interface BrokerageApi {
+
+    Money computeBuyFee(BrokerAccountId accountId, Quantity quantity, Money price);
+
+    void applyCashFlow(BrokerAccountId accountId, Money delta);
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/application/exception/PortfolioNotFoundException.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/application/exception/PortfolioNotFoundException.java
@@ -1,0 +1,9 @@
+package com.budiyanto.fintrackr.portfolio.application.exception;
+
+import com.budiyanto.fintrackr.portfolio.domain.model.PortfolioId;
+
+public class PortfolioNotFoundException extends  RuntimeException {
+    public PortfolioNotFoundException(PortfolioId portfolioId) {
+        super("Portfolio not found. ID: " + portfolioId);
+    }
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/application/port/in/RecordBuyCommand.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/application/port/in/RecordBuyCommand.java
@@ -1,0 +1,17 @@
+package com.budiyanto.fintrackr.portfolio.application.port.in;
+
+import com.budiyanto.fintrackr.portfolio.domain.model.PortfolioId;
+import com.budiyanto.fintrackr.shared.AssetId;
+import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.Quantity;
+
+import java.time.LocalDate;
+
+public record RecordBuyCommand(
+        PortfolioId portfolioId,
+        AssetId assetId,
+        Quantity quantity,
+        Money price,
+        Money fee, // null → fee is computed from the broker's FeeStructure
+        LocalDate date
+) { }

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/application/port/in/RecordBuyUseCase.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/application/port/in/RecordBuyUseCase.java
@@ -1,0 +1,7 @@
+package com.budiyanto.fintrackr.portfolio.application.port.in;
+
+public interface RecordBuyUseCase {
+
+    void handle(RecordBuyCommand command);
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/application/port/out/PortfolioRepository.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/application/port/out/PortfolioRepository.java
@@ -1,0 +1,14 @@
+package com.budiyanto.fintrackr.portfolio.application.port.out;
+
+import com.budiyanto.fintrackr.portfolio.domain.model.Portfolio;
+import com.budiyanto.fintrackr.portfolio.domain.model.PortfolioId;
+
+import java.util.Optional;
+
+public interface PortfolioRepository {
+
+    Optional<Portfolio> findById(PortfolioId id);
+
+    Portfolio save(Portfolio portfolio);
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/application/service/RecordBuyService.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/application/service/RecordBuyService.java
@@ -1,0 +1,43 @@
+package com.budiyanto.fintrackr.portfolio.application.service;
+
+import com.budiyanto.fintrackr.brokerage.BrokerageApi;
+import com.budiyanto.fintrackr.portfolio.application.exception.PortfolioNotFoundException;
+import com.budiyanto.fintrackr.portfolio.application.port.in.RecordBuyCommand;
+import com.budiyanto.fintrackr.portfolio.application.port.in.RecordBuyUseCase;
+import com.budiyanto.fintrackr.portfolio.application.port.out.PortfolioRepository;
+import com.budiyanto.fintrackr.portfolio.domain.model.Portfolio;
+import com.budiyanto.fintrackr.shared.Money;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class RecordBuyService implements RecordBuyUseCase {
+
+    private final PortfolioRepository portfolioRepository;
+    private final BrokerageApi brokerageApi;
+    private final Clock clock;
+
+    @Override
+    public void handle(RecordBuyCommand command) {
+        Optional<Portfolio> portfolioOptional = portfolioRepository.findById(command.portfolioId());
+        if  (portfolioOptional.isEmpty()) {
+            throw new PortfolioNotFoundException(command.portfolioId());
+        }
+
+        Portfolio portfolio = portfolioOptional.get();
+
+        Money fee = Optional.ofNullable(command.fee())
+                .orElseGet(() -> brokerageApi.computeBuyFee(portfolio.brokerAccountId(), command.quantity(), command.price()));
+
+        LocalDate today = LocalDate.now(clock);
+        Money delta = portfolio.recordBuy(command.assetId(), command.quantity(), command.price(), fee, command.date(), today);
+        portfolioRepository.save(portfolio);
+
+        brokerageApi.applyCashFlow(portfolio.brokerAccountId(), delta);
+
+    }
+
+}

--- a/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
+++ b/src/main/java/com/budiyanto/fintrackr/portfolio/domain/model/Portfolio.java
@@ -95,6 +95,10 @@ public class Portfolio {
 
     public PortfolioId id() { return id; }
 
+    public String name() { return name; }
+
+    public BrokerAccountId brokerAccountId() { return brokerAccountId; }
+
     public Money tradingBalance() { return tradingBalance; }
 
     public List<Transaction> transactions() { return List.copyOf(transactions); }

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/application/service/InMemoryBrokerageApi.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/application/service/InMemoryBrokerageApi.java
@@ -1,0 +1,33 @@
+package com.budiyanto.fintrackr.portfolio.application.service;
+
+import com.budiyanto.fintrackr.brokerage.BrokerageApi;
+import com.budiyanto.fintrackr.brokerage.domain.model.BrokerAccount;
+import com.budiyanto.fintrackr.shared.BrokerAccountId;
+import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.Quantity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InMemoryBrokerageApi implements BrokerageApi {
+
+    private final Map<BrokerAccountId, BrokerAccount> brokerAccounts = new HashMap<>();
+
+    @Override
+    public Money computeBuyFee(BrokerAccountId accountId, Quantity quantity, Money price) {
+        return brokerAccounts.get(accountId).computeBuyFee(quantity, price);
+    }
+
+    @Override
+    public void applyCashFlow(BrokerAccountId accountId, Money delta) {
+        brokerAccounts.get(accountId).applyCashFlow(delta);
+    }
+
+    void addBrokerAccount(BrokerAccount brokerAccount) {
+        brokerAccounts.put(brokerAccount.id(), brokerAccount);
+    }
+
+    void clear() {
+        brokerAccounts.clear();
+    }
+}

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/application/service/InMemoryPortfolioRepository.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/application/service/InMemoryPortfolioRepository.java
@@ -1,0 +1,30 @@
+package com.budiyanto.fintrackr.portfolio.application.service;
+
+import com.budiyanto.fintrackr.portfolio.application.port.out.PortfolioRepository;
+import com.budiyanto.fintrackr.portfolio.domain.model.Portfolio;
+import com.budiyanto.fintrackr.portfolio.domain.model.PortfolioId;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class InMemoryPortfolioRepository implements PortfolioRepository {
+
+    private final Map<PortfolioId, Portfolio> portfolios = new HashMap<>();
+
+    @Override
+    public Optional<Portfolio> findById(PortfolioId id) {
+        return Optional.ofNullable(portfolios.get(id));
+    }
+
+    @Override
+    public Portfolio save(Portfolio portfolio) {
+        portfolios.put(portfolio.id(), portfolio);
+        return portfolio;
+    }
+
+    void clear() {
+        portfolios.clear();
+    }
+
+}

--- a/src/test/java/com/budiyanto/fintrackr/portfolio/application/service/RecordBuyServiceTest.java
+++ b/src/test/java/com/budiyanto/fintrackr/portfolio/application/service/RecordBuyServiceTest.java
@@ -1,0 +1,133 @@
+package com.budiyanto.fintrackr.portfolio.application.service;
+
+import com.budiyanto.fintrackr.brokerage.domain.model.BrokerAccount;
+import com.budiyanto.fintrackr.brokerage.domain.model.FeeStructure;
+import com.budiyanto.fintrackr.brokerage.domain.model.Percentage;
+import com.budiyanto.fintrackr.portfolio.application.exception.PortfolioNotFoundException;
+import com.budiyanto.fintrackr.portfolio.application.port.in.RecordBuyCommand;
+import com.budiyanto.fintrackr.portfolio.domain.exception.InsufficientBalanceException;
+import com.budiyanto.fintrackr.portfolio.domain.model.Portfolio;
+import com.budiyanto.fintrackr.portfolio.domain.model.PortfolioId;
+import com.budiyanto.fintrackr.shared.AssetId;
+import com.budiyanto.fintrackr.shared.Money;
+import com.budiyanto.fintrackr.shared.Quantity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("RecordBuy Tests")
+class RecordBuyServiceTest {
+
+    private final InMemoryPortfolioRepository inMemoryPortfolioRepository = new InMemoryPortfolioRepository();
+    private final InMemoryBrokerageApi inMemoryBrokerageApi = new InMemoryBrokerageApi();
+    private final Clock clock = Clock.fixed(Instant.parse("2026-08-23T00:00:00Z"), ZoneId.systemDefault());
+    private final RecordBuyService recordBuyService =  new RecordBuyService(inMemoryPortfolioRepository, inMemoryBrokerageApi, clock);
+
+    private Portfolio portfolio;
+    private BrokerAccount brokerAccount;
+
+    private final AssetId assetId = AssetId.of("ID1000109507"); // BBCA ISIN
+    private final Quantity quantity = Quantity.ofShares(new BigDecimal("1000"));
+    private final Money price = Money.of(new BigDecimal("5000"));
+    private final Money fee = Money.of(new BigDecimal("1250"));
+    private final Money initialDeposit = Money.of(new BigDecimal("6000000"));
+
+    @BeforeEach
+    void setup() {
+        brokerAccount = BrokerAccount.create("Test Broker Account", FeeStructure.of(Percentage.of(new BigDecimal("0.0015")), Percentage.of(new BigDecimal("0.0025"))));
+        brokerAccount.applyCashFlow(initialDeposit);
+        inMemoryBrokerageApi.addBrokerAccount(brokerAccount);
+
+        portfolio = Portfolio.create(brokerAccount.id(), "Test Portfolio");
+        portfolio.recordDeposit(initialDeposit, LocalDate.now(), LocalDate.now());
+        inMemoryPortfolioRepository.save(portfolio);
+    }
+
+    @Test
+    @DisplayName("Reduce portfolio trading balance and broker account RDN when record buy is recorded")
+    void should_reduceTradingBalanceAndRdn_when_recordBuy() {
+        // Given
+        var command = new RecordBuyCommand(portfolio.id(), assetId, quantity, price, fee, LocalDate.now());
+
+        // When
+        recordBuyService.handle(command);
+
+        // Then
+        assertThat(portfolio.tradingBalance()).isEqualTo(Money.of(new BigDecimal("998750"))); // 6000000 - (1000 * 5000 + 1250) = 998750
+        assertThat(brokerAccount.rdn()).isEqualTo(Money.of(new BigDecimal("998750"))); // 6000000 - (1000 * 5000 + 1250) = 998.750
+        assertThat(brokerAccount.rdn()).isEqualTo(portfolio.tradingBalance());
+    }
+
+    @Test
+    @DisplayName("Have sum(tradingBalance) == rdn when record buy is recorded on multiple portfolios")
+    void should_haveEqualRdnAndAllPortfolioTradingBalance_when_recordBuyInMultiplePortfolios() {
+        // Given
+        Money secondDeposit = Money.of(new BigDecimal("10000000"));
+        brokerAccount.applyCashFlow(secondDeposit);
+
+        var command1 = new RecordBuyCommand(portfolio.id(), assetId, quantity, price, fee, LocalDate.now());
+
+        Portfolio portfolio2 = Portfolio.create(brokerAccount.id(), "Test Portfolio 2");
+        portfolio2.recordDeposit(secondDeposit, LocalDate.now(), LocalDate.now());
+        inMemoryPortfolioRepository.save(portfolio2);
+        var command2 = new RecordBuyCommand(portfolio2.id(), assetId, quantity, price, fee, LocalDate.now());
+
+        // When
+        recordBuyService.handle(command1);
+        recordBuyService.handle(command2);
+
+        // Then
+        assertThat(brokerAccount.rdn()).isEqualTo(portfolio.tradingBalance().add(portfolio2.tradingBalance()));
+    }
+
+    @Test
+    @DisplayName("Use computed fee when no fee is given in command")
+    void should_useComputedFee_when_noFeeIsGivenInCommand() {
+        // Given
+        var command = new RecordBuyCommand(portfolio.id(), assetId, quantity, price, null, LocalDate.now());
+
+        // When
+        recordBuyService.handle(command);
+
+        // Then
+        assertThat(portfolio.tradingBalance()).isEqualTo(Money.of(new BigDecimal("992500"))); // 6000000 - (1000 * 5000 + 7500) = 992500
+        assertThat(brokerAccount.rdn()).isEqualTo(Money.of(new BigDecimal("992500"))); // 6000000 - (1000 * 5000 + 7500) = 992500
+        assertThat(brokerAccount.rdn()).isEqualTo(portfolio.tradingBalance());
+    }
+
+    @Test
+    @DisplayName("Reject a record buy when the portfolio is not found")
+    void should_throwException_when_portfolioNotFound() {
+        // Given
+        var command = new RecordBuyCommand(PortfolioId.generate(), assetId, quantity, price, fee, LocalDate.now());
+
+        // When & Assert
+        assertThatThrownBy(() -> recordBuyService.handle(command))
+                .isInstanceOf(PortfolioNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("Reject a record buy when the balance is insufficient")
+    void should_throwException_when_balanceIsInsufficient() {
+        // Given
+        var command = new RecordBuyCommand(portfolio.id(), assetId, Quantity.ofShares(new BigDecimal("10000")), price, fee, LocalDate.now());
+
+        // When & Then
+        assertThatThrownBy(() -> recordBuyService.handle(command))
+                .isInstanceOf(InsufficientBalanceException.class);
+
+        assertThat(portfolio.tradingBalance()).isEqualTo(initialDeposit);
+        assertThat(brokerAccount.rdn()).isEqualTo(initialDeposit);
+    }
+
+}


### PR DESCRIPTION
First application service. `RecordBuyUseCase` loads the `Portfolio`, resolves the fee (compute-by-default via Brokerage's published API, caller override wins), records the buy on the aggregate, saves it, and applies the signed cash delta to the broker RDN through `BrokerageApi`.

- Hexagonal ports: `RecordBuyUseCase` + `RecordBuyCommand`  (port/in), `PortfolioRepository` (port/out); `RecordBuyService` (application/service).
- PM calls Brokerage only through its published `BrokerageApi` interface (ADR-003).
- Fee resolution: `Optional.ofNullable(command.fee()).orElseGet(computeBuyFee)` — lazy, so no needless cross-module call when a fee is supplied.
- Clock injected; aggregate stays clock-free.
- Detroit tests with in-memory fakes delegating to real aggregates: happy-path invariant, `sum(tradingBalances)==rdn` across two portfolios, computed fee, portfolio-not-found, insufficient-balance-leaves-state-unchanged.

Deferred: `@Transactional`/`@Service` wiring + rollback integration test (needs persistence).